### PR TITLE
Issue #16

### DIFF
--- a/src/x11api.c
+++ b/src/x11api.c
@@ -46,7 +46,8 @@ int get_next_key_state(Display *display)
     if (XGetEventData(display, cookie) && cookie->type == GenericEvent)
     {
         XIDeviceEvent *event = cookie->data;
-        button = event->detail;
+        if (!(event->flags & XIKeyRepeat))
+            button = event->detail;
     }
 
     XFreeEventData(display, cookie);


### PR DESCRIPTION
Check for event flag XIKeyRepeat when evaluating key state to filter out key repeating.

Tested in XFCE in Manjaro 21.2.0