### PR TITLE
Clarify repeat UI

### DIFF
--- a/src/resources/ui/xclicker-window.ui
+++ b/src/resources/ui/xclicker-window.ui
@@ -230,7 +230,7 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="repeat_only_check">
-                        <property name="label" translatable="yes">Repeat only:</property>
+                        <property name="label" translatable="yes">Repeat Only</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="focus-on-click">False</property>
@@ -246,10 +246,12 @@
                     <child>
                       <object class="GtkEntry" id="repeat_entry">
                         <property name="name">MinutesEntry</property>
+                        <property name="width-request">105</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can-focus">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">end</property>
+                        <property name="hexpand">False</property>
                         <property name="max-length">9</property>
                         <property name="width-chars">0</property>
                         <property name="placeholder-text"># of times</property>

--- a/src/resources/ui/xclicker-window.ui
+++ b/src/resources/ui/xclicker-window.ui
@@ -230,7 +230,7 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="repeat_only_check">
-                        <property name="label" translatable="yes">Repeat Only</property>
+                        <property name="label" translatable="yes">Repeat only:</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="focus-on-click">False</property>
@@ -252,6 +252,7 @@
                         <property name="hexpand">True</property>
                         <property name="max-length">9</property>
                         <property name="width-chars">0</property>
+                        <property name="placeholder-text"># of times</property>
                         <signal name="insert-text" handler="insert_handler" swapped="no"/>
                       </object>
                       <packing>


### PR DESCRIPTION
Clarify repeat UI - link the label to the text field and add a placeholder.

Didn't actually test & compile it, don't have the build system setup - let me know if it needs adjusting.

Fixes https://github.com/robiot/xclicker/issues/20.