### PR TITLE
Add the 'hold' feature as requested by #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ XClicker is an open-source, easy to use, feature-rich, **blazing fast** Autoclic
  * Safe mode, to protect from unwanted behaviour;
  * Autoclick with a specified amount of time between each click;
  * Choose mouse button [Left/Right/Middle];
- * Choose click type [Single/Double];
+ * Choose click type [Single/Double/Hold];
  * Repeat until stopped or repeat a given amount of times;
  * Click on a specified location only;
  * Randomize the click interval;

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -6,12 +6,12 @@
 #include "settings.h"
 #include "macros.h"
 
-enum ClickTypes {
+enum ClickTypes
+{
 	CLICK_TYPE_SINGLE,
 	CLICK_TYPE_DOUBLE,
 	CLICK_TYPE_HOLD,
 };
-
 
 gboolean isClicking = FALSE;
 gboolean isChoosingLocation = FALSE;
@@ -124,16 +124,12 @@ void click_handler(gpointer *data)
 				g_printerr("Error when sending click");
 			break;
 		case CLICK_TYPE_HOLD:
-			if (count == 0) // don't re-send mouse_down if already successfully sent
+			if (count == 0) // Don't re-send mouse_down if already successfully sent
 			{
 				if (mouse_event(display, args->button, is_using_xevent(), MOUSE_EVENT_PRESS))
-				{
 					count++;
-				}
 				else
-				{
 					g_printerr("Error when sending mouse down");
-				}
 			}
 			break;
 		}
@@ -305,7 +301,7 @@ void open_safe_mode_dialog()
 /**
  * Grab click options from ui and pass them to click_opts, then start click_handler.
  * @see click_handler
-*/
+ */
 void start_clicked()
 {
 	int sleep = get_text_to_int(mainappwindow.hours_entry) * 3600000 + get_text_to_int(mainappwindow.minutes_entry) * 60000 + get_text_to_int(mainappwindow.seconds_entry) * 1000 + get_text_to_int(mainappwindow.millisecs_entry);
@@ -350,13 +346,13 @@ void start_clicked()
 		data->random_interval_ms = get_text_to_int(mainappwindow.random_interval_entry);
 
 	// If holding, ignore interval and repeat as it makes no sense. Set an interval of 250ms to prevent cpu high usage
-	if(data->click_type == CLICK_TYPE_HOLD)
+	if (data->click_type == CLICK_TYPE_HOLD)
 	{
 		data->repeat = FALSE;
 		data->random_interval = FALSE;
 		data->sleep = 250;
 	}
-	
+
 	g_thread_new("click_handler", click_handler, data);
 }
 

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -103,6 +103,8 @@ void click_handler(gpointer *data)
 	struct click_opts *args = data;
 	Display *display = get_display();
 	int count = 0;
+	gboolean is_holding = FALSE;
+
 	while (isClicking)
 	{
 		if (args->custom_location)
@@ -124,10 +126,10 @@ void click_handler(gpointer *data)
 				g_printerr("Error when sending click");
 			break;
 		case CLICK_TYPE_HOLD:
-			if (count == 0) // Don't re-send mouse_down if already successfully sent
+			if (is_holding == FALSE) // Don't re-send mouse_down if already successfully sent
 			{
 				if (mouse_event(display, args->button, is_using_xevent(), MOUSE_EVENT_PRESS))
-					count++;
+					is_holding = TRUE;
 				else
 					g_printerr("Error when sending mouse down");
 			}

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -123,7 +123,7 @@ void click_handler(gpointer *data)
 		case CLICK_TYPE_HOLD:
 			if (count == 0) // don't re-send mouse_down if already successfully sent
 			{
-				if (mouse_down(display, args->button, is_using_xevent()))
+				if (mouse_event(display, args->button, is_using_xevent(), MOUSE_PRESSED))
 				{
 					count++;
 				}
@@ -157,7 +157,7 @@ void click_handler(gpointer *data)
 	// If it was a mouse hold, then release the button
 	if (args->click_type == CLICK_TYPE_HOLD)
 	{
-		if (mouse_up(display, args->button, is_using_xevent()) == FALSE)
+		if (mouse_event(display, args->button, is_using_xevent(), MOUSE_RELEASED) == FALSE)
 			g_printerr("Error when sending mouse down");
 	}
 

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -376,7 +376,7 @@ void get_button_clicked()
 	g_thread_new("get_cursor_pos_handler", get_cursor_pos_handler, NULL);
 }
 
-void click_type_entry_changed(/*GtkComboBox* self, gpointer user_data*/)
+void click_type_entry_changed()
 {
 	const gchar *click_type_text = gtk_entry_get_text(GTK_ENTRY(mainappwindow.click_type_entry));
 	gboolean active = TRUE;

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -158,7 +158,7 @@ void click_handler(gpointer *data)
 	// If it was a mouse hold, then release the button
 	if (args->click_type == CLICK_TYPE_HOLD)
 	{
-		if (mouse_event(display, args->button, is_using_xevent(), MOUSE_RELEASE) == FALSE)
+		if (mouse_event(display, args->button, is_using_xevent(), MOUSE_EVENT_RELEASE) == FALSE)
 			g_printerr("Error when sending mouse down");
 	}
 

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -6,9 +6,12 @@
 #include "settings.h"
 #include "macros.h"
 
-#define CLICK_TYPE_SINGLE 0
-#define CLICK_TYPE_DOUBLE 1
-#define CLICK_TYPE_HOLD 2
+enum ClickTypes {
+	CLICK_TYPE_SINGLE,
+	CLICK_TYPE_DOUBLE,
+	CLICK_TYPE_HOLD,
+};
+
 
 gboolean isClicking = FALSE;
 gboolean isChoosingLocation = FALSE;
@@ -123,7 +126,7 @@ void click_handler(gpointer *data)
 		case CLICK_TYPE_HOLD:
 			if (count == 0) // don't re-send mouse_down if already successfully sent
 			{
-				if (mouse_event(display, args->button, is_using_xevent(), MOUSE_PRESSED))
+				if (mouse_event(display, args->button, is_using_xevent(), MOUSE_EVENT_PRESS))
 				{
 					count++;
 				}
@@ -157,7 +160,7 @@ void click_handler(gpointer *data)
 	// If it was a mouse hold, then release the button
 	if (args->click_type == CLICK_TYPE_HOLD)
 	{
-		if (mouse_event(display, args->button, is_using_xevent(), MOUSE_RELEASED) == FALSE)
+		if (mouse_event(display, args->button, is_using_xevent(), MOUSE_RELEASE) == FALSE)
 			g_printerr("Error when sending mouse down");
 	}
 

--- a/src/resources/ui/xclicker-window.ui
+++ b/src/resources/ui/xclicker-window.ui
@@ -14,6 +14,9 @@
       <row>
         <col id="0" translatable="yes">Double</col>
       </row>
+      <row>
+        <col id="0" translatable="yes">Hold</col>
+      </row>
     </data>
   </object>
   <object class="GtkListStore" id="repeat_amount_lstore">
@@ -322,6 +325,7 @@
                             <property name="caps-lock-warning">False</property>
                           </object>
                         </child>
+                        <signal name="changed" handler="click_type_entry_changed" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>

--- a/src/x11api.c
+++ b/src/x11api.c
@@ -117,15 +117,13 @@ int mouse_down(Display *display, int button, int mode)
 
         // Press
         event.type = ButtonPress;
-        if (!cxevent(display, ButtonPressMask, event))
-            return FALSE;
-        break;
+        return cxevent(display, ButtonPressMask, event);
 
     case CLICK_MODE_XTEST:
         XTestFakeButtonEvent(display, button, True, CurrentTime);
         XFlush(display);
+        break;
     }
-
     return TRUE;
 }
 
@@ -138,15 +136,13 @@ int mouse_up(Display *display, int button, int mode)
 
         // Press
         event.type = ButtonRelease;
-        if (!cxevent(display, ButtonPressMask, event))
-            return FALSE;
-        break;
+        return cxevent(display, ButtonPressMask, event);
 
     case CLICK_MODE_XTEST:
         XTestFakeButtonEvent(display, button, False, CurrentTime);
         XFlush(display);
+        break;
     }
-
     return TRUE;
 }
 

--- a/src/x11api.c
+++ b/src/x11api.c
@@ -127,7 +127,7 @@ int click(Display *display, int button, int mode)
         return FALSE;
     if (mode == CLICK_MODE_XTEST)
         usleep(DEFAULT_MICRO_SLEEP);
-    return mouse_event(display, button, mode, MOUSE_RELEASE);
+    return mouse_event(display, button, mode, MOUSE_EVENT_RELEASE);
 }
 
 char *keycode_to_string(Display *display, int keycode)

--- a/src/x11api.c
+++ b/src/x11api.c
@@ -108,7 +108,7 @@ XButtonEvent make_event(Display *display, int button)
     return event;
 }
 
-int mouse_down(Display *display, int button, int mode)
+int mouse_event(Display *display, int button, int mode, enum MouseEvents event_type)
 {
     switch (mode)
     {
@@ -116,30 +116,11 @@ int mouse_down(Display *display, int button, int mode)
         XButtonEvent event = make_event(display, button);
 
         // Press
-        event.type = ButtonPress;
+        event.type = (event_type == MOUSE_PRESSED) ? ButtonPress : ButtonRelease;
         return cxevent(display, ButtonPressMask, event);
 
     case CLICK_MODE_XTEST:
-        XTestFakeButtonEvent(display, button, True, CurrentTime);
-        XFlush(display);
-        break;
-    }
-    return TRUE;
-}
-
-int mouse_up(Display *display, int button, int mode)
-{
-    switch (mode)
-    {
-    case CLICK_MODE_XEVENT:
-        XButtonEvent event = make_event(display, button);
-
-        // Press
-        event.type = ButtonRelease;
-        return cxevent(display, ButtonPressMask, event);
-
-    case CLICK_MODE_XTEST:
-        XTestFakeButtonEvent(display, button, False, CurrentTime);
+        XTestFakeButtonEvent(display, button, (event_type == MOUSE_PRESSED), CurrentTime);
         XFlush(display);
         break;
     }
@@ -148,11 +129,11 @@ int mouse_up(Display *display, int button, int mode)
 
 int click(Display *display, int button, int mode)
 {
-    if (!mouse_down(display, button, mode))
+    if (!mouse_event(display, button, mode, MOUSE_PRESSED))
         return FALSE;
     if (mode == CLICK_MODE_XTEST)
         usleep(DEFAULT_MICRO_SLEEP);
-    return mouse_up(display, button, mode);
+    return mouse_event(display, button, mode, MOUSE_RELEASED);
 }
 
 char *keycode_to_string(Display *display, int keycode)

--- a/src/x11api.h
+++ b/src/x11api.h
@@ -7,7 +7,8 @@
 #define MASK_CONFIG_MOUSE (0)
 #define MASK_CONFIG_KEYBOARD (1)
 
-enum ClickModes {
+enum ClickModes
+{
     CLICK_MODE_XTEST,
     CLICK_MODE_XEVENT,
 };

--- a/src/x11api.h
+++ b/src/x11api.h
@@ -36,6 +36,26 @@ void get_cursor_coords(Display *display, int *x, int *y);
 void move_to(Display *display, int x, int y);
 
 /**
+ * Mouse down on current mouse position with given button.
+ * There is two modes, xtest and xevent. Xevent is generally more safe since it doesn't interact with gnome-shell, titlebars and gtk_applications.
+ * Xevent also only clicks the currently focused application.
+ * XTest is like mouse_event on windows. It focuses the application the cursor is hovering
+ * over and clicks on everything that xevent can't plus what xevent can.
+ * @param mode The mode to use to click [CLICK_MODE_XTEST/CLICK_MODE_XEVENT]
+ */
+int mouse_down(Display *display, int button, int mode);
+
+/**
+ * Mouse up on current mouse position with given button.
+ * There is two modes, xtest and xevent. Xevent is generally more safe since it doesn't interact with gnome-shell, titlebars and gtk_applications.
+ * Xevent also only clicks the currently focused application.
+ * XTest is like mouse_event on windows. It focuses the application the cursor is hovering
+ * over and clicks on everything that xevent can't plus what xevent can.
+ * @param mode The mode to use to click [CLICK_MODE_XTEST/CLICK_MODE_XEVENT]
+ */
+int mouse_up(Display *display, int button, int mode);
+
+/**
  * Click on current mouse position with given button.
  * There is two modes, xtest and xevent. Xevent is generally more safe since it doesn't interact with gnome-shell, titlebars and gtk_applications.
  * Xevent also only clicks the currently focused application.

--- a/src/x11api.h
+++ b/src/x11api.h
@@ -11,6 +11,16 @@
 #define CLICK_MODE_XEVENT (1)
 
 /**
+ * @brief Enumeration of the supported mouse events.
+ * @see mouse_event
+ */
+enum MouseEvents
+{
+    MOUSE_PRESSED,
+    MOUSE_RELEASED
+};
+
+/**
  * Configure XInput masks for the given display.
  * @param display The display to configure, get with get_display()
  * @param mode The mode to configure for [MASK_CONFIG_MOUSE/MASK_CONFIG_KEYBOARD]
@@ -36,24 +46,14 @@ void get_cursor_coords(Display *display, int *x, int *y);
 void move_to(Display *display, int x, int y);
 
 /**
- * Mouse down on current mouse position with given button.
+ * Mouse event on current mouse position with given button.
  * There is two modes, xtest and xevent. Xevent is generally more safe since it doesn't interact with gnome-shell, titlebars and gtk_applications.
  * Xevent also only clicks the currently focused application.
  * XTest is like mouse_event on windows. It focuses the application the cursor is hovering
  * over and clicks on everything that xevent can't plus what xevent can.
  * @param mode The mode to use to click [CLICK_MODE_XTEST/CLICK_MODE_XEVENT]
  */
-int mouse_down(Display *display, int button, int mode);
-
-/**
- * Mouse up on current mouse position with given button.
- * There is two modes, xtest and xevent. Xevent is generally more safe since it doesn't interact with gnome-shell, titlebars and gtk_applications.
- * Xevent also only clicks the currently focused application.
- * XTest is like mouse_event on windows. It focuses the application the cursor is hovering
- * over and clicks on everything that xevent can't plus what xevent can.
- * @param mode The mode to use to click [CLICK_MODE_XTEST/CLICK_MODE_XEVENT]
- */
-int mouse_up(Display *display, int button, int mode);
+int mouse_event(Display *display, int button, int mode, enum MouseEvents event_type);
 
 /**
  * Click on current mouse position with given button.

--- a/src/x11api.h
+++ b/src/x11api.h
@@ -20,7 +20,7 @@ enum ClickModes
 enum MouseEvents
 {
     MOUSE_EVENT_PRESS,
-    MOUSE_RELEASE,
+    MOUSE_EVENT_RELEASE,
 };
 
 /**

--- a/src/x11api.h
+++ b/src/x11api.h
@@ -7,8 +7,10 @@
 #define MASK_CONFIG_MOUSE (0)
 #define MASK_CONFIG_KEYBOARD (1)
 
-#define CLICK_MODE_XTEST (0) // Default
-#define CLICK_MODE_XEVENT (1)
+enum ClickModes {
+    CLICK_MODE_XTEST,
+    CLICK_MODE_XEVENT,
+};
 
 /**
  * @brief Enumeration of the supported mouse events.
@@ -16,8 +18,8 @@
  */
 enum MouseEvents
 {
-    MOUSE_PRESSED,
-    MOUSE_RELEASED
+    MOUSE_EVENT_PRESS,
+    MOUSE_RELEASE,
 };
 
 /**


### PR DESCRIPTION
Select the 'Hold' value in the 'Click type'. It disable widgets that
make no sense in such situation. Emits the 'mouse down' event on start,
and 'mouse up' on stop.

Signed-off-by: ctxnop <ctxnop@gmail.com>