### PR TITLE
Remember all options after restart and add button to reset in settings

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1,0 +1,137 @@
+#include <gtk/gtk.h>
+#include "config.h"
+#include "x11api.h"
+
+const char *configpath;
+GKeyFile *config_gfile;
+
+// The config struct
+struct Config *config;
+
+const char *get_config_file_path()
+{
+    const char *config_path = g_get_user_config_dir();
+    const char *file_name = "/xclicker.conf";
+
+    if (!opendir(config_path))
+    {
+        g_printerr("Could not find any path to get or store the settings in.\n");
+        return NULL;
+    }
+
+    char *config_file_path = malloc(strlen(config_path) + strlen(file_name) + 1);
+    strcpy(config_file_path, config_path);
+    strcat(config_file_path, "/xclicker.conf");
+
+    return config_file_path;
+}
+
+GKeyFile *get_config_keyfile(const char *config_path)
+{
+    GKeyFile *config = g_key_file_new();
+
+    // Reversed boolean
+    if (access(config_path, F_OK) == 0 && !g_key_file_load_from_file(config, config_path, G_KEY_FILE_KEEP_COMMENTS, NULL))
+        g_print("The config file seems to be corrupted.\n");
+
+    return config;
+}
+
+void config_init()
+{
+    Display *display = get_display();
+
+    configpath = get_config_file_path();
+    config_gfile = get_config_keyfile(configpath);
+
+    config = config_read_from_file();
+
+    XCloseDisplay(display);
+}
+
+void save_and_populate_config()
+{
+    g_key_file_save_to_file(config_gfile, configpath, NULL);
+    config = config_read_from_file();
+}
+
+gboolean is_safemode()
+{
+    if (config->safe_mode_enabled == TRUE)
+        return TRUE;
+    if (access(configpath, F_OK))
+        return TRUE;
+
+    return FALSE;
+}
+
+void load_start_stop_keybinds(struct Config *config)
+{
+    Display *display = get_display();
+    const int button_1 = g_key_file_get_integer(config_gfile, CFGK_BUTTON_1, NULL);
+    const int button_2 = g_key_file_get_integer(config_gfile, CFGK_BUTTON_2, NULL);
+
+    // Initial values
+    config->button1 = -1;
+    config->button2 = XKeysymToKeycode(display, XK_F8);
+
+    if (button_1 != 0 && button_1)
+        config->button1 = button_1;
+
+    if (button_2 != 0 && button_2)
+        config->button2 = button_2;
+
+    XCloseDisplay(display);
+}
+
+struct Config *config_read_from_file()
+{
+    struct Config *config = g_malloc0(sizeof(*config));
+
+    // config->button1 = g_key_file_get_integer(config_gfile, CFGK_BUTTON_1, NULL);
+    // config->button2 = g_key_file_get_integer(config_gfile, CFGK_BUTTON_2, NULL);
+    load_start_stop_keybinds(config); // Makes it work
+
+    config->safe_mode_enabled = g_key_file_get_boolean(config_gfile, CFGK_SAFEMODE, NULL);
+    config->use_xevent = g_key_file_get_boolean(config_gfile, CFGK_USE_XEVENT, NULL);
+
+    config->hours = g_key_file_get_string(config_gfile, PCK_HOURS, NULL);
+    config->minutes = g_key_file_get_string(config_gfile, PCK_MINUTES, NULL);
+    config->seconds = g_key_file_get_string(config_gfile, PCK_SECONDS, NULL);
+    config->millisecs = g_key_file_get_string(config_gfile, PCK_MILLISECS, NULL);
+    if (!config->millisecs)
+    {
+        config->millisecs = "100";
+    }
+
+    config->mouse_button = g_key_file_get_string(config_gfile, PCK_MOUSE_BUTTON, NULL);
+    if (!config->mouse_button)
+    {
+        config->mouse_button = "Left";
+    }
+
+    config->click_type = g_key_file_get_string(config_gfile, PCK_CLICK_TYPE, NULL);
+    if (!config->click_type)
+    {
+        config->click_type = "Single";
+    }
+
+    config->hotkey = g_key_file_get_string(config_gfile, PCK_HOTKEY, NULL);
+    if (!config->hotkey)
+    {
+        config->hotkey = "Normal";
+    }
+
+    config->use_repeat = g_key_file_get_boolean(config_gfile, PCK_REPEAT, NULL);
+    config->repeat_times = g_key_file_get_string(config_gfile, PCK_REPEAT_TIMES, NULL);
+
+    config->use_custom_location = g_key_file_get_boolean(config_gfile, PCK_CUSTOM_LOCATION, NULL);
+    config->custom_x = g_key_file_get_string(config_gfile, PCK_CUSTOM_X, NULL);
+    config->custom_y = g_key_file_get_string(config_gfile, PCK_CUSTOM_Y, NULL);
+    config->use_random_interval = g_key_file_get_boolean(config_gfile, PCK_RANDOM_INTERVAL, NULL);
+    config->random_interval_ms = g_key_file_get_string(config_gfile, PCK_RANDOM_INTERVAL_MS, NULL);
+    config->use_hold_time = g_key_file_get_boolean(config_gfile, PCK_HOLD_TIME, NULL);
+    config->hold_time_ms = g_key_file_get_string(config_gfile, PCK_HOLD_TIME_MS, NULL);
+
+    return config;
+}

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,90 @@
+#ifndef __CONFIG_H
+#define __CONFIG_H
+#include <gtk/gtk.h>
+
+/**
+ * Represents all options you can see when starting xclicker.
+ * kindof sus atm because the options are updated live,
+ * but other options are just updated on start and whenever you open settings
+ * please dont use config->(anything other than options) unless it is for initialisation
+ */
+struct Config
+{
+	/// options
+	int button1;
+	int button2;
+	gboolean safe_mode_enabled;
+	gboolean use_xevent;
+
+	/// click interval
+	const char *hours;
+	const char *minutes;
+	const char *seconds;
+	const char *millisecs;
+
+	/// opitons
+	const char *mouse_button;
+	const char *click_type;
+	const char *hotkey;
+	gboolean use_repeat;
+	const char *repeat_times;
+
+	/// more options
+	gboolean use_custom_location;
+	const char *custom_x;
+	const char *custom_y;
+	gboolean use_random_interval;
+	const char *random_interval_ms;
+	gboolean use_hold_time;
+	const char *hold_time_ms;
+};
+
+extern const char *configpath;
+extern GKeyFile *config_gfile;
+extern struct Config *config;
+
+#define CONFIG_CATEGORY_OPTIONS "Options"
+#define PRESET_CATEGORY_CLICK_INTERVAL "Preset.Click Interval"
+#define PRESET_CATEGORY_OPTIONS "Preset.Options"
+#define PRESET_CATEGORY_MORE_OPTIONS "Preset.More Options"
+
+// config keys
+#define CFGK_BUTTON_1 CONFIG_CATEGORY_OPTIONS, "BUTTON1"
+#define CFGK_BUTTON_2 CONFIG_CATEGORY_OPTIONS, "BUTTON2"
+#define CFGK_USE_XEVENT CONFIG_CATEGORY_OPTIONS, "USE_XEVENT"
+#define CFGK_SAFEMODE CONFIG_CATEGORY_OPTIONS, "SAFEMODE"
+
+/// PCK stand for preset-category-key. Below set of defines used to prevent typos
+#define PCK_HOURS PRESET_CATEGORY_CLICK_INTERVAL, "Hours"
+#define PCK_MINUTES PRESET_CATEGORY_CLICK_INTERVAL, "Minutes"
+#define PCK_SECONDS PRESET_CATEGORY_CLICK_INTERVAL, "Seconds"
+#define PCK_MILLISECS PRESET_CATEGORY_CLICK_INTERVAL, "Millisecs"
+
+#define PCK_MOUSE_BUTTON PRESET_CATEGORY_OPTIONS, "Millisecs"
+#define PCK_CLICK_TYPE PRESET_CATEGORY_OPTIONS, "Click Type"
+#define PCK_HOTKEY PRESET_CATEGORY_OPTIONS, "Hotkey"
+#define PCK_REPEAT PRESET_CATEGORY_OPTIONS, "Use Repeat"
+#define PCK_REPEAT_TIMES PRESET_CATEGORY_OPTIONS, "Repeat Times"
+
+#define PCK_CUSTOM_LOCATION PRESET_CATEGORY_MORE_OPTIONS, "Use Custom Location"
+#define PCK_CUSTOM_X PRESET_CATEGORY_MORE_OPTIONS, "Custom X"
+#define PCK_CUSTOM_Y PRESET_CATEGORY_MORE_OPTIONS, "Custom Y"
+#define PCK_RANDOM_INTERVAL PRESET_CATEGORY_MORE_OPTIONS, "Use Random Interval"
+#define PCK_RANDOM_INTERVAL_MS PRESET_CATEGORY_MORE_OPTIONS, "Random Interval ms"
+#define PCK_HOLD_TIME PRESET_CATEGORY_MORE_OPTIONS, "Use Hold Time"
+#define PCK_HOLD_TIME_MS PRESET_CATEGORY_MORE_OPTIONS, "Hold Time ms"
+
+void config_init();
+
+void save_and_populate_config();
+
+/**
+ * Checks if configured to use safe-mode.
+ */
+gboolean is_safemode();
+
+/**
+ * Read config values from the config.
+ */
+struct Config *config_read_from_file();
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -9,10 +9,12 @@
 #include <gtk/gtk.h>
 #include <X11/Xlib.h>
 #include "xclicker-app.h"
+#include "config.h"
 
 int main(int argc, char *argv[])
 {
     XInitThreads();
     srand(time(NULL));
+
     return g_application_run(G_APPLICATION(xclicker_app_new()), argc, argv);
 }

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -656,6 +656,8 @@ static void main_app_window_class_init(MainAppWindowClass *class)
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), insert_handler);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), start_clicked);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), stop_clicked);
+	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), load_preset_clicked);
+	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), save_preset_clicked);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), click_type_entry_changed);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), repeat_only_check_toggle);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), settings_clicked);

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -1,5 +1,3 @@
-#include <string.h>
-#include <error.h>
 #include <gtk/gtk.h>
 #include <sys/time.h>
 #include "xclicker-app.h"
@@ -92,13 +90,6 @@ int random_between(int lower, int upper)
 int get_text_to_int(GtkWidget *entry)
 {
 	return atoi(gtk_entry_get_text(GTK_ENTRY(entry)));
-}
-
-void set_text_from_int(GtkWidget *entry, int value)
-{
-	char text[64] = {0};
-	sprintf(text, "%d", value);
-	gtk_entry_set_text(entry, text);
 }
 
 /**

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -5,6 +5,7 @@
 #include "x11api.h"
 #include "settings.h"
 #include "utils.h"
+#include "config.h"
 
 enum ClickTypes
 {
@@ -111,7 +112,7 @@ void click_handler(gpointer *data)
 	int count = 0;
 	gboolean is_holding = FALSE;
 
-	gboolean using_xevent = is_using_xevent();
+	gboolean using_xevent = config->use_xevent;
 
 	int hold_type_ms = args->hold_time == TRUE ? args->hold_time_ms * 1000 : 0;
 
@@ -168,7 +169,7 @@ void click_handler(gpointer *data)
 	// If it was a mouse hold, then release the button
 	if (args->click_type == CLICK_TYPE_HOLD)
 	{
-		if (mouse_event(display, args->button, is_using_xevent(), MOUSE_EVENT_RELEASE) == FALSE)
+		if (mouse_event(display, args->button, config->use_xevent, MOUSE_EVENT_RELEASE) == FALSE)
 			xapp_error("Sending mouse down", -1);
 	}
 
@@ -202,6 +203,7 @@ void set_coords(gpointer *data)
 		gtk_entry_set_text(mainappwindow.x_entry, args->coordx);
 	if (GTK_IS_ENTRY(mainappwindow.y_entry))
 		gtk_entry_set_text(mainappwindow.y_entry, args->coordy);
+
 	g_free(args);
 }
 
@@ -284,6 +286,9 @@ void get_cursor_pos_handler()
 void repeat_only_check_toggle(GtkToggleButton *check)
 {
 	gtk_widget_set_sensitive(mainappwindow.repeat_entry, gtk_toggle_button_get_active(check));
+
+	g_key_file_set_boolean(config_gfile, PCK_REPEAT, gtk_toggle_button_get_active(check));
+	save_and_populate_config();
 }
 
 void custom_location_check_toggle(GtkToggleButton *check)
@@ -292,6 +297,9 @@ void custom_location_check_toggle(GtkToggleButton *check)
 	gtk_widget_set_sensitive(mainappwindow.x_entry, active);
 	gtk_widget_set_sensitive(mainappwindow.y_entry, active);
 	gtk_widget_set_sensitive(mainappwindow.get_button, active);
+
+	g_key_file_set_boolean(config_gfile, PCK_CUSTOM_LOCATION, active);
+	save_and_populate_config();
 }
 
 /**
@@ -303,6 +311,52 @@ void insert_handler(GtkEditable *editable, const gchar *text)
 	{
 		g_signal_stop_emission_by_name(editable, "insert_text");
 	}
+}
+
+// Input change events
+void input_changed_save_handler(GtkEditable *editable, struct _MainAppWindow *mainappwindow)
+{
+	GtkEntry *entry = GTK_ENTRY(editable);
+	const gchar *text = gtk_entry_get_text(entry);
+
+	if (editable == GTK_EDITABLE(mainappwindow->hours_entry))
+	{
+		g_key_file_set_string(config_gfile, PCK_HOURS, text);
+	}
+	else if (editable == GTK_EDITABLE(mainappwindow->minutes_entry))
+	{
+		g_key_file_set_string(config_gfile, PCK_MINUTES, text);
+	}
+	else if (editable == GTK_EDITABLE(mainappwindow->seconds_entry))
+	{
+		g_key_file_set_string(config_gfile, PCK_SECONDS, text);
+	}
+	else if (editable == GTK_EDITABLE(mainappwindow->millisecs_entry))
+	{
+		g_key_file_set_string(config_gfile, PCK_MILLISECS, text);
+	}
+	else if (editable == GTK_EDITABLE(mainappwindow->repeat_entry))
+	{
+		g_key_file_set_string(config_gfile, PCK_REPEAT_TIMES, text);
+	}
+	else if (editable == GTK_EDITABLE(mainappwindow->random_interval_entry))
+	{
+		g_key_file_set_string(config_gfile, PCK_RANDOM_INTERVAL_MS, text);
+	}
+	else if (editable == GTK_EDITABLE(mainappwindow->hold_time_entry))
+	{
+		g_key_file_set_string(config_gfile, PCK_HOLD_TIME_MS, text);
+	}
+	else if (editable == GTK_EDITABLE(mainappwindow->x_entry))
+	{
+		g_key_file_set_string(config_gfile, PCK_CUSTOM_X, text);
+	}
+	else if (editable == GTK_EDITABLE(mainappwindow->y_entry))
+	{
+		g_key_file_set_string(config_gfile, PCK_CUSTOM_Y, text);
+	}
+
+	save_and_populate_config();
 }
 
 void open_safe_mode_dialog()
@@ -384,64 +438,26 @@ void stop_clicked()
 	toggle_buttons();
 }
 
-struct Preset *mainappwindow_export_preset()
+void mainappwindow_import_config()
 {
-	struct Preset *preset = g_malloc0(sizeof(*preset));
+	gtk_entry_set_text_if_not_null(mainappwindow.hours_entry, config->hours);
+	gtk_entry_set_text_if_not_null(mainappwindow.minutes_entry, config->minutes);
+	gtk_entry_set_text_if_not_null(mainappwindow.seconds_entry, config->seconds);
+	gtk_entry_set_text_if_not_null(mainappwindow.millisecs_entry, config->millisecs);
 
-	preset->hours               = gtk_entry_get_text(mainappwindow.hours_entry);
-	preset->minutes             = gtk_entry_get_text(mainappwindow.minutes_entry);
-	preset->seconds             = gtk_entry_get_text(mainappwindow.seconds_entry);
-	preset->millisecs           = gtk_entry_get_text(mainappwindow.millisecs_entry);
+	gtk_entry_set_text_if_not_null(mainappwindow.mouse_entry, config->mouse_button);
+	gtk_entry_set_text_if_not_null(mainappwindow.click_type_entry, config->click_type);
+	gtk_entry_set_text_if_not_null(mainappwindow.hotkey_type_entry, config->hotkey);
+	gtk_toggle_button_set_active(mainappwindow.repeat_only_check, config->use_repeat);
+	gtk_entry_set_text_if_not_null(mainappwindow.repeat_entry, config->repeat_times);
 
-	preset->mouse_button        = gtk_entry_get_text(mainappwindow.mouse_entry);
-	preset->click_type          = gtk_entry_get_text(mainappwindow.click_type_entry);
-	preset->hotkey              = gtk_entry_get_text(mainappwindow.hotkey_type_entry);
-	preset->use_repeat          = gtk_toggle_button_get_active(mainappwindow.repeat_only_check);
-	preset->repeat_times        = gtk_entry_get_text(mainappwindow.repeat_entry);
-
-	preset->use_custom_location = gtk_toggle_button_get_active(mainappwindow.custom_location_check);
-	preset->custom_x            = gtk_entry_get_text(mainappwindow.x_entry);
-	preset->custom_y            = gtk_entry_get_text(mainappwindow.y_entry);
-	preset->use_random_interval = gtk_toggle_button_get_active(mainappwindow.random_interval_check);
-	preset->random_interval_ms  = gtk_entry_get_text(mainappwindow.random_interval_entry);
-	preset->use_hold_time       = gtk_toggle_button_get_active(mainappwindow.hold_time_check);
-	preset->hold_time_ms        = gtk_entry_get_text(mainappwindow.hold_time_entry);
-
-	return preset;
-}
-
-void save_preset_clicked()
-{
-	preset_write_to_config(mainappwindow_export_preset());
-}
-
-void mainappwindow_import_preset(struct Preset *preset)
-{
-	gtk_entry_set_text(mainappwindow.hours_entry, preset->hours);
-	gtk_entry_set_text(mainappwindow.minutes_entry, preset->minutes);
-	gtk_entry_set_text(mainappwindow.seconds_entry, preset->seconds);
-	gtk_entry_set_text(mainappwindow.millisecs_entry, preset->millisecs);
-
-	gtk_entry_set_text(mainappwindow.mouse_entry, preset->mouse_button);
-	gtk_entry_set_text(mainappwindow.click_type_entry, preset->click_type);
-	gtk_entry_set_text(mainappwindow.hotkey_type_entry, preset->hotkey);
-	gtk_toggle_button_set_active(mainappwindow.repeat_only_check, preset->use_repeat);
-	gtk_entry_set_text(mainappwindow.repeat_entry, preset->repeat_times);
-
-	gtk_toggle_button_set_active(mainappwindow.custom_location_check, preset->use_custom_location);
-	gtk_entry_set_text(mainappwindow.x_entry, preset->custom_x);
-	gtk_entry_set_text(mainappwindow.y_entry, preset->custom_y);
-	gtk_toggle_button_set_active(mainappwindow.random_interval_check, preset->use_random_interval);
-	gtk_entry_set_text(mainappwindow.random_interval_entry, preset->random_interval_ms);
-	gtk_toggle_button_set_active(mainappwindow.hold_time_check, preset->use_hold_time);
-	gtk_entry_set_text(mainappwindow.hold_time_entry, preset->hold_time_ms);
-
-	g_free(preset);
-}
-
-void load_preset_clicked()
-{
-	mainappwindow_import_preset(preset_read_from_config());
+	gtk_toggle_button_set_active(mainappwindow.custom_location_check, config->use_custom_location);
+	gtk_entry_set_text_if_not_null(mainappwindow.x_entry, config->custom_x);
+	gtk_entry_set_text_if_not_null(mainappwindow.y_entry, config->custom_y);
+	gtk_toggle_button_set_active(mainappwindow.random_interval_check, config->use_random_interval);
+	gtk_entry_set_text_if_not_null(mainappwindow.random_interval_entry, config->random_interval_ms);
+	gtk_toggle_button_set_active(mainappwindow.hold_time_check, config->use_hold_time);
+	gtk_entry_set_text_if_not_null(mainappwindow.hold_time_entry, config->hold_time_ms);
 }
 
 void settings_clicked()
@@ -466,6 +482,9 @@ void click_type_entry_changed()
 		active = FALSE;
 	}
 
+	g_key_file_set_string(config_gfile, PCK_CLICK_TYPE, click_type_text);
+	g_key_file_save_to_file(config_gfile, configpath, NULL);
+
 	gtk_widget_set_sensitive(mainappwindow.hours_entry, active);
 	gtk_widget_set_sensitive(mainappwindow.minutes_entry, active);
 	gtk_widget_set_sensitive(mainappwindow.seconds_entry, active);
@@ -476,6 +495,22 @@ void click_type_entry_changed()
 	gtk_widget_set_sensitive(mainappwindow.random_interval_entry, active);
 	gtk_widget_set_sensitive(mainappwindow.hold_time_check, active);
 	gtk_widget_set_sensitive(mainappwindow.hold_time_entry, active);
+}
+
+void hotkey_type_entry_changed()
+{
+	const gchar *hotkey_type_text = gtk_entry_get_text(GTK_ENTRY(mainappwindow.hotkey_type_entry));
+
+	g_key_file_set_string(config_gfile, PCK_HOTKEY, hotkey_type_text);
+	g_key_file_save_to_file(config_gfile, configpath, NULL);
+}
+
+void mouse_button_entry_changed()
+{
+	const gchar *mouse_button_entry_text = gtk_entry_get_text(GTK_ENTRY(mainappwindow.mouse_entry));
+
+	g_key_file_set_string(config_gfile, PCK_MOUSE_BUTTON, mouse_button_entry_text);
+	g_key_file_save_to_file(config_gfile, configpath, NULL);
 }
 
 void toggle_clicking(int evtype)
@@ -519,10 +554,10 @@ void get_start_stop_key_handler()
 		if (isChoosingHotkey == TRUE)
 			continue;
 
-		if (keyState.button == button1 || keyState.button == button2)
+		if (keyState.button == config->button1 || keyState.button == config->button2)
 		{
 			// Two buttons
-			if (button1 != -1)
+			if (config->button1 != -1)
 			{
 				if (isHolding1 || isHolding2)
 				{
@@ -535,8 +570,8 @@ void get_start_stop_key_handler()
 				toggle_clicking(keyState.evtype);
 			}
 
-			isHolding1 = keyState.button == button1 && keyState.evtype == KeyPress;
-			isHolding2 = keyState.button == button2 && keyState.evtype == KeyPress;
+			isHolding1 = keyState.button == config->button1 && keyState.evtype == KeyPress;
+			isHolding2 = keyState.button == config->button2 && keyState.evtype == KeyPress;
 		}
 	}
 
@@ -550,15 +585,15 @@ void set_start_stop_button_hotkey_text()
 	const char *stop_text_1 = "Stop";
 
 	// Button2 should always be defined
-	const char *button_2_key = keycode_to_string(display, button2);
+	const char *button_2_key = keycode_to_string(display, config->button2);
 
 	char *start_text;
 	char *stop_text;
 
 	// If 2 keys
-	if (button1 != -1)
+	if (config->button1 != -1)
 	{
-		const char *button_1_key = keycode_to_string(display, button1);
+		const char *button_1_key = keycode_to_string(display, config->button1);
 		start_text = malloc(strlen(start_text_1) + strlen(button_1_key) + strlen(button_2_key) + 4);
 		stop_text = malloc(strlen(stop_text_1) + strlen(button_1_key) + strlen(button_2_key) + 4);
 		sprintf(start_text, "%s (%s+%s)", start_text_1, button_1_key, button_2_key);
@@ -592,6 +627,9 @@ void set_start_stop_button_hotkey_text()
 void random_interval_check_toggle(GtkToggleButton *self)
 {
 	gtk_widget_set_sensitive(mainappwindow.random_interval_entry, gtk_toggle_button_get_active(self));
+
+	g_key_file_set_boolean(config_gfile, PCK_RANDOM_INTERVAL, gtk_toggle_button_get_active(self));
+	save_and_populate_config();
 }
 
 /**
@@ -600,6 +638,9 @@ void random_interval_check_toggle(GtkToggleButton *self)
 void hold_time_check_toggle(GtkToggleButton *self)
 {
 	gtk_widget_set_sensitive(mainappwindow.hold_time_entry, gtk_toggle_button_get_active(self));
+
+	g_key_file_set_boolean(config_gfile, PCK_HOLD_TIME, gtk_toggle_button_get_active(self));
+	save_and_populate_config();
 }
 
 /**
@@ -612,7 +653,6 @@ static void main_app_window_init(MainAppWindow *win)
 
 	gtk_widget_init_template(GTK_WIDGET(win));
 	config_init();
-	load_start_stop_keybinds();
 
 	mainappwindow.pwin = gtk_widget_get_toplevel(win);
 
@@ -643,6 +683,8 @@ static void main_app_window_init(MainAppWindow *win)
 	mainappwindow.get_button = win->get_button;
 
 	set_start_stop_button_hotkey_text();
+	mainappwindow_import_config();
+
 	g_thread_new("get_start_stop_key_handler", get_start_stop_key_handler, NULL);
 }
 
@@ -656,10 +698,11 @@ static void main_app_window_class_init(MainAppWindowClass *class)
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), insert_handler);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), start_clicked);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), stop_clicked);
-	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), load_preset_clicked);
-	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), save_preset_clicked);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), click_type_entry_changed);
+	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), mouse_button_entry_changed);
+	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), hotkey_type_entry_changed);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), repeat_only_check_toggle);
+	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), input_changed_save_handler);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), settings_clicked);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), custom_location_check_toggle);
 	gtk_widget_class_bind_template_callback(GTK_WIDGET_CLASS(class), get_button_clicked);

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -1,3 +1,5 @@
+#include <string.h>
+#include <error.h>
 #include <gtk/gtk.h>
 #include <sys/time.h>
 #include "xclicker-app.h"
@@ -473,7 +475,16 @@ void load_preset_clicked()
 {
 	struct click_opts *data = g_malloc0(sizeof(struct click_opts));
 	FILE *preset = fopen(preset_filename, "r");
-	fread(data, sizeof(*data), 1, preset);
+	if (preset == NULL)
+	{
+		fprintf(stderr, "ERROR: %s '%s'\n", strerror(errno), preset_filename);
+		exit(1);
+	}
+	if (!fread(data, sizeof(*data), 1, preset))
+	{
+		fprintf(stderr, "ERROR: can not read '%s'. %s\n", preset_filename, strerror(errno));
+		exit(1);
+	}
 	fclose(preset);
 	set_click_opts(data);
 }

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -7,6 +7,12 @@
 #define MAIN_APP_WINDOW_TYPE (main_app_window_get_type())
 G_DECLARE_FINAL_TYPE(MainAppWindow, main_app_window, XCLICKER, APP_WINDOW, GtkApplicationWindow)
 
+
+/**
+ * Set corresponding fields to their imported config value
+*/
+void mainappwindow_import_config();
+
 /**
  * Set the Start & Stop button text from configured hotkey
  */

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,6 +9,7 @@ xclicker_resources = gnome.compile_resources(
 executable('xclicker',
     'main.c', 
     'xclicker-app.c',
+    'config.c',
     'mainwin.c',
     'x11api.c',
     'settings.c',

--- a/src/resources/ui/settings-dialog.ui
+++ b/src/resources/ui/settings-dialog.ui
@@ -214,6 +214,52 @@ gtk applications.</property>
           </packing>
         </child>
         <child>
+          <object class="GtkFrame">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="spacing">10</property>
+                <property name="homogeneous">True</property>
+                <child>
+                  <object class="GtkButton" id="reset_preset_button">
+                    <property name="label" translatable="yes">Reset preset options</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <signal name="pressed" handler="reset_preset_button_pressed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Reset</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
           <!-- n-columns=1 n-rows=2 -->
           <object class="GtkGrid">
             <property name="visible">True</property>

--- a/src/resources/ui/xclicker-window.ui
+++ b/src/resources/ui/xclicker-window.ui
@@ -238,7 +238,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Mouse Button</property>
-                        <property name="xalign">0.20000000298023224</property>
+                        <property name="xalign">0.2</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -277,7 +277,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Click Type</property>
-                        <property name="xalign">0.07999999821186065</property>
+                        <property name="xalign">0.08</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -317,7 +317,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Hotkey</property>
-                        <property name="xalign">0.10000000149011612</property>
+                        <property name="xalign">0.1</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -559,9 +559,6 @@
                         <property name="left-attach">1</property>
                         <property name="top-attach">3</property>
                       </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
                     </child>
                   </object>
                 </child>

--- a/src/resources/ui/xclicker-window.ui
+++ b/src/resources/ui/xclicker-window.ui
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.22" />
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkListStore" id="click_type_lstore">
     <columns>
       <!-- column-name gchararray1 -->
-      <column type="gchararray" />
+      <column type="gchararray"/>
     </columns>
     <data>
       <row>
@@ -19,10 +19,24 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="hotkey_lstore">
+    <columns>
+      <!-- column-name gchararray1 -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Normal</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Hold</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkListStore" id="mouse_button_lstore">
     <columns>
       <!-- column-name gchararray1 -->
-      <column type="gchararray" />
+      <column type="gchararray"/>
     </columns>
     <data>
       <row>
@@ -33,20 +47,6 @@
       </row>
       <row>
         <col id="0" translatable="yes">Middle</col>
-      </row>
-    </data>
-  </object>
-  <object class="GtkListStore" id="hotkey_lstore">
-    <columns>
-      <!-- column-name gchararray1 -->
-      <column type="gchararray" />
-    </columns>
-    <data>
-      <row>
-        <col id="0" translatable="yes">Normal</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">Hold</col>
       </row>
     </data>
   </object>
@@ -102,7 +102,7 @@
                     <property name="hexpand">True</property>
                     <property name="max-length">9</property>
                     <property name="width-chars">0</property>
-                    <signal name="insert-text" handler="insert_handler" swapped="no" />
+                    <signal name="insert-text" handler="insert_handler" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -153,7 +153,7 @@
                     <property name="hexpand">True</property>
                     <property name="max-length">9</property>
                     <property name="width-chars">0</property>
-                    <signal name="insert-text" handler="insert_handler" swapped="no" />
+                    <signal name="insert-text" handler="insert_handler" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left-attach">2</property>
@@ -168,7 +168,7 @@
                     <property name="hexpand">True</property>
                     <property name="max-length">9</property>
                     <property name="width-chars">0</property>
-                    <signal name="insert-text" handler="insert_handler" swapped="no" />
+                    <signal name="insert-text" handler="insert_handler" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
@@ -185,7 +185,7 @@
                     <property name="max-length">9</property>
                     <property name="width-chars">0</property>
                     <property name="text" translatable="yes">100</property>
-                    <signal name="insert-text" handler="insert_handler" swapped="no" />
+                    <signal name="insert-text" handler="insert_handler" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left-attach">3</property>
@@ -223,7 +223,7 @@
                 <property name="label-xalign">0</property>
                 <property name="shadow-type">in</property>
                 <child>
-                  <!-- n-columns=2 n-rows=3 -->
+                  <!-- n-columns=2 n-rows=4 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -238,7 +238,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Mouse Button</property>
-                        <property name="xalign">0.2</property>
+                        <property name="xalign">0.20000000298023224</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -255,7 +255,7 @@
                         <property name="id-column">0</property>
                         <property name="active-id">-1</property>
                         <child>
-                          <object class="GtkCellRendererText" />
+                          <object class="GtkCellRendererText"/>
                         </child>
                         <child internal-child="entry">
                           <object class="GtkEntry" id="mouse_entry">
@@ -272,13 +272,12 @@
                         <property name="top-attach">0</property>
                       </packing>
                     </child>
-
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Click Type</property>
-                        <property name="xalign">0.08</property>
+                        <property name="xalign">0.07999999821186065</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -294,8 +293,9 @@
                         <property name="entry-text-column">0</property>
                         <property name="id-column">0</property>
                         <property name="active-id">-1</property>
+                        <signal name="changed" handler="click_type_entry_changed" swapped="no"/>
                         <child>
-                          <object class="GtkCellRendererText" />
+                          <object class="GtkCellRendererText"/>
                         </child>
                         <child internal-child="entry">
                           <object class="GtkEntry" id="click_type_entry">
@@ -306,20 +306,18 @@
                             <property name="caps-lock-warning">False</property>
                           </object>
                         </child>
-                        <signal name="changed" handler="click_type_entry_changed" swapped="no" />
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">1</property>
                       </packing>
                     </child>
-
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Hotkey</property>
-                        <property name="xalign">0.1</property>
+                        <property name="xalign">0.10000000149011612</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -335,8 +333,9 @@
                         <property name="entry-text-column">0</property>
                         <property name="id-column">0</property>
                         <property name="active-id">-1</property>
+                        <signal name="changed" handler="click_type_entry_changed" swapped="no"/>
                         <child>
-                          <object class="GtkCellRendererText" />
+                          <object class="GtkCellRendererText"/>
                         </child>
                         <child internal-child="entry">
                           <object class="GtkEntry" id="hotkey_type_entry">
@@ -347,14 +346,12 @@
                             <property name="caps-lock-warning">False</property>
                           </object>
                         </child>
-                        <signal name="changed" handler="click_type_entry_changed" swapped="no" />
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">2</property>
                       </packing>
                     </child>
-
                     <child>
                       <object class="GtkCheckButton" id="repeat_only_check">
                         <property name="label" translatable="yes">Repeat</property>
@@ -363,7 +360,7 @@
                         <property name="focus-on-click">False</property>
                         <property name="receives-default">False</property>
                         <property name="draw-indicator">True</property>
-                        <signal name="toggled" handler="repeat_only_check_toggle" swapped="no" />
+                        <signal name="toggled" handler="repeat_only_check_toggle" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -382,7 +379,7 @@
                         <property name="max-length">9</property>
                         <property name="width-chars">0</property>
                         <property name="placeholder-text"># of times</property>
-                        <signal name="insert-text" handler="insert_handler" swapped="no" />
+                        <signal name="insert-text" handler="insert_handler" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
@@ -411,7 +408,7 @@
                 <property name="label-xalign">0</property>
                 <property name="shadow-type">in</property>
                 <child>
-                  <!-- n-columns=2 n-rows=3 -->
+                  <!-- n-columns=2 n-rows=4 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -429,7 +426,7 @@
                         <property name="focus-on-click">False</property>
                         <property name="receives-default">False</property>
                         <property name="draw-indicator">True</property>
-                        <signal name="toggled" handler="custom_location_check_toggle" swapped="no" />
+                        <signal name="toggled" handler="custom_location_check_toggle" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -445,7 +442,7 @@
                         <property name="focus-on-click">False</property>
                         <property name="receives-default">True</property>
                         <property name="hexpand">True</property>
-                        <signal name="pressed" handler="get_button_clicked" swapped="no" />
+                        <signal name="pressed" handler="get_button_clicked" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
@@ -468,7 +465,7 @@
                             <property name="max-length">9</property>
                             <property name="width-chars">0</property>
                             <property name="placeholder-text" translatable="yes">X</property>
-                            <signal name="insert-text" handler="insert_handler" swapped="no" />
+                            <signal name="insert-text" handler="insert_handler" swapped="no"/>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
@@ -485,7 +482,7 @@
                             <property name="max-length">9</property>
                             <property name="width-chars">0</property>
                             <property name="placeholder-text" translatable="yes">Y</property>
-                            <signal name="insert-text" handler="insert_handler" swapped="no" />
+                            <signal name="insert-text" handler="insert_handler" swapped="no"/>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
@@ -498,7 +495,6 @@
                         <property name="top-attach">1</property>
                       </packing>
                     </child>
-
                     <child>
                       <object class="GtkCheckButton" id="random_interval_check">
                         <property name="label" translatable="yes">Random Interval</property>
@@ -508,7 +504,7 @@
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Randomize the interval in milliseconds</property>
                         <property name="draw-indicator">True</property>
-                        <signal name="toggled" handler="random_interval_check_toggle" swapped="no" />
+                        <signal name="toggled" handler="random_interval_check_toggle" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -525,14 +521,13 @@
                         <property name="max-length">6</property>
                         <property name="width-chars">0</property>
                         <property name="placeholder-text" translatable="yes">+/-</property>
-                        <signal name="insert-text" handler="insert_handler" swapped="no" />
+                        <signal name="insert-text" handler="insert_handler" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">2</property>
                       </packing>
                     </child>
-
                     <child>
                       <object class="GtkCheckButton" id="hold_time_check">
                         <property name="label" translatable="yes">Hold Time</property>
@@ -541,7 +536,7 @@
                         <property name="focus-on-click">False</property>
                         <property name="receives-default">False</property>
                         <property name="draw-indicator">True</property>
-                        <signal name="toggled" handler="hold_time_check_toggle" swapped="no" />
+                        <signal name="toggled" handler="hold_time_check_toggle" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -558,14 +553,16 @@
                         <property name="max-length">6</property>
                         <property name="width-chars">0</property>
                         <property name="placeholder-text" translatable="yes">ms</property>
-                        <signal name="insert-text" handler="insert_handler" swapped="no" />
+                        <signal name="insert-text" handler="insert_handler" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">3</property>
                       </packing>
                     </child>
-
+                    <child>
+                      <placeholder/>
+                    </child>
                   </object>
                 </child>
                 <child type="label">
@@ -589,6 +586,68 @@
           </packing>
         </child>
         <child>
+          <object class="GtkFrame" id="preset_frame">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="margin-start">4</property>
+            <property name="margin-end">4</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <!-- n-columns=2 n-rows=1 -->
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="column-spacing">15</property>
+                <property name="row-homogeneous">True</property>
+                <property name="column-homogeneous">True</property>
+                <child>
+                  <object class="GtkButton" id="save_preset_button">
+                    <property name="label" translatable="yes">Save</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <signal name="pressed" handler="save_preset_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="load_preset_button">
+                    <property name="label" translatable="yes">Load</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <signal name="pressed" handler="load_preset_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Preset</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
           <!-- n-columns=3 n-rows=1 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
@@ -605,7 +664,7 @@
                 <property name="focus-on-click">False</property>
                 <property name="receives-default">True</property>
                 <property name="hexpand">True</property>
-                <signal name="pressed" handler="start_clicked" swapped="no" />
+                <signal name="pressed" handler="start_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="left-attach">0</property>
@@ -621,7 +680,7 @@
                 <property name="focus-on-click">False</property>
                 <property name="receives-default">True</property>
                 <property name="hexpand">True</property>
-                <signal name="pressed" handler="stop_clicked" swapped="no" />
+                <signal name="pressed" handler="stop_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="left-attach">1</property>
@@ -638,7 +697,7 @@
                 <property name="receives-default">True</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
-                <signal name="pressed" handler="settings_clicked" swapped="no" />
+                <signal name="pressed" handler="settings_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="left-attach">2</property>
@@ -649,7 +708,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/src/resources/ui/xclicker-window.ui
+++ b/src/resources/ui/xclicker-window.ui
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.40.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.22"/>
+  <requires lib="gtk+" version="3.22" />
   <object class="GtkListStore" id="click_type_lstore">
     <columns>
       <!-- column-name gchararray1 -->
-      <column type="gchararray"/>
+      <column type="gchararray" />
     </columns>
     <data>
       <row>
@@ -19,24 +19,10 @@
       </row>
     </data>
   </object>
-  <object class="GtkListStore" id="hotkey_lstore">
-    <columns>
-      <!-- column-name gchararray1 -->
-      <column type="gchararray"/>
-    </columns>
-    <data>
-      <row>
-        <col id="0" translatable="yes">Normal</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">Hold</col>
-      </row>
-    </data>
-  </object>
   <object class="GtkListStore" id="mouse_button_lstore">
     <columns>
       <!-- column-name gchararray1 -->
-      <column type="gchararray"/>
+      <column type="gchararray" />
     </columns>
     <data>
       <row>
@@ -47,6 +33,20 @@
       </row>
       <row>
         <col id="0" translatable="yes">Middle</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="hotkey_lstore">
+    <columns>
+      <!-- column-name gchararray1 -->
+      <column type="gchararray" />
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Normal</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Hold</col>
       </row>
     </data>
   </object>
@@ -102,7 +102,8 @@
                     <property name="hexpand">True</property>
                     <property name="max-length">9</property>
                     <property name="width-chars">0</property>
-                    <signal name="insert-text" handler="insert_handler" swapped="no"/>
+                    <signal name="insert-text" handler="insert_handler" swapped="no" />
+                    <signal name="changed" handler="input_changed_save_handler" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -153,7 +154,8 @@
                     <property name="hexpand">True</property>
                     <property name="max-length">9</property>
                     <property name="width-chars">0</property>
-                    <signal name="insert-text" handler="insert_handler" swapped="no"/>
+                    <signal name="insert-text" handler="insert_handler" swapped="no" />
+                    <signal name="changed" handler="input_changed_save_handler" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left-attach">2</property>
@@ -168,7 +170,8 @@
                     <property name="hexpand">True</property>
                     <property name="max-length">9</property>
                     <property name="width-chars">0</property>
-                    <signal name="insert-text" handler="insert_handler" swapped="no"/>
+                    <signal name="insert-text" handler="insert_handler" swapped="no" />
+                    <signal name="changed" handler="input_changed_save_handler" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
@@ -185,7 +188,8 @@
                     <property name="max-length">9</property>
                     <property name="width-chars">0</property>
                     <property name="text" translatable="yes">100</property>
-                    <signal name="insert-text" handler="insert_handler" swapped="no"/>
+                    <signal name="insert-text" handler="insert_handler" swapped="no" />
+                    <signal name="changed" handler="input_changed_save_handler" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left-attach">3</property>
@@ -223,7 +227,7 @@
                 <property name="label-xalign">0</property>
                 <property name="shadow-type">in</property>
                 <child>
-                  <!-- n-columns=2 n-rows=4 -->
+                  <!-- n-columns=2 n-rows=3 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -255,7 +259,7 @@
                         <property name="id-column">0</property>
                         <property name="active-id">-1</property>
                         <child>
-                          <object class="GtkCellRendererText"/>
+                          <object class="GtkCellRendererText" />
                         </child>
                         <child internal-child="entry">
                           <object class="GtkEntry" id="mouse_entry">
@@ -266,12 +270,14 @@
                             <property name="caps-lock-warning">False</property>
                           </object>
                         </child>
+                        <signal name="changed" handler="mouse_button_entry_changed" swapped="no" />
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">0</property>
                       </packing>
                     </child>
+
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
@@ -293,9 +299,8 @@
                         <property name="entry-text-column">0</property>
                         <property name="id-column">0</property>
                         <property name="active-id">-1</property>
-                        <signal name="changed" handler="click_type_entry_changed" swapped="no"/>
                         <child>
-                          <object class="GtkCellRendererText"/>
+                          <object class="GtkCellRendererText" />
                         </child>
                         <child internal-child="entry">
                           <object class="GtkEntry" id="click_type_entry">
@@ -306,12 +311,14 @@
                             <property name="caps-lock-warning">False</property>
                           </object>
                         </child>
+                        <signal name="changed" handler="click_type_entry_changed" swapped="no" />
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">1</property>
                       </packing>
                     </child>
+
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
@@ -333,9 +340,8 @@
                         <property name="entry-text-column">0</property>
                         <property name="id-column">0</property>
                         <property name="active-id">-1</property>
-                        <signal name="changed" handler="click_type_entry_changed" swapped="no"/>
                         <child>
-                          <object class="GtkCellRendererText"/>
+                          <object class="GtkCellRendererText" />
                         </child>
                         <child internal-child="entry">
                           <object class="GtkEntry" id="hotkey_type_entry">
@@ -346,12 +352,14 @@
                             <property name="caps-lock-warning">False</property>
                           </object>
                         </child>
+                        <signal name="changed" handler="hotkey_type_entry_changed" swapped="no" />
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">2</property>
                       </packing>
                     </child>
+
                     <child>
                       <object class="GtkCheckButton" id="repeat_only_check">
                         <property name="label" translatable="yes">Repeat</property>
@@ -360,7 +368,7 @@
                         <property name="focus-on-click">False</property>
                         <property name="receives-default">False</property>
                         <property name="draw-indicator">True</property>
-                        <signal name="toggled" handler="repeat_only_check_toggle" swapped="no"/>
+                        <signal name="toggled" handler="repeat_only_check_toggle" swapped="no" />
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -369,7 +377,7 @@
                     </child>
                     <child>
                       <object class="GtkEntry" id="repeat_entry">
-                        <property name="name">MinutesEntry</property>
+                        <property name="name">RepeatEntry</property>
                         <property name="width-request">105</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
@@ -379,7 +387,8 @@
                         <property name="max-length">9</property>
                         <property name="width-chars">0</property>
                         <property name="placeholder-text"># of times</property>
-                        <signal name="insert-text" handler="insert_handler" swapped="no"/>
+                        <signal name="insert-text" handler="insert_handler" swapped="no" />
+                        <signal name="changed" handler="input_changed_save_handler" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
@@ -408,7 +417,7 @@
                 <property name="label-xalign">0</property>
                 <property name="shadow-type">in</property>
                 <child>
-                  <!-- n-columns=2 n-rows=4 -->
+                  <!-- n-columns=2 n-rows=3 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -426,7 +435,7 @@
                         <property name="focus-on-click">False</property>
                         <property name="receives-default">False</property>
                         <property name="draw-indicator">True</property>
-                        <signal name="toggled" handler="custom_location_check_toggle" swapped="no"/>
+                        <signal name="toggled" handler="custom_location_check_toggle" swapped="no" />
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -442,7 +451,7 @@
                         <property name="focus-on-click">False</property>
                         <property name="receives-default">True</property>
                         <property name="hexpand">True</property>
-                        <signal name="pressed" handler="get_button_clicked" swapped="no"/>
+                        <signal name="pressed" handler="get_button_clicked" swapped="no" />
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
@@ -465,7 +474,8 @@
                             <property name="max-length">9</property>
                             <property name="width-chars">0</property>
                             <property name="placeholder-text" translatable="yes">X</property>
-                            <signal name="insert-text" handler="insert_handler" swapped="no"/>
+                            <signal name="insert-text" handler="insert_handler" swapped="no" />
+                            <signal name="changed" handler="input_changed_save_handler" swapped="no"/>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
@@ -482,7 +492,8 @@
                             <property name="max-length">9</property>
                             <property name="width-chars">0</property>
                             <property name="placeholder-text" translatable="yes">Y</property>
-                            <signal name="insert-text" handler="insert_handler" swapped="no"/>
+                            <signal name="insert-text" handler="insert_handler" swapped="no" />
+                            <signal name="changed" handler="input_changed_save_handler" swapped="no"/>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
@@ -495,6 +506,7 @@
                         <property name="top-attach">1</property>
                       </packing>
                     </child>
+
                     <child>
                       <object class="GtkCheckButton" id="random_interval_check">
                         <property name="label" translatable="yes">Random Interval</property>
@@ -504,7 +516,7 @@
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Randomize the interval in milliseconds</property>
                         <property name="draw-indicator">True</property>
-                        <signal name="toggled" handler="random_interval_check_toggle" swapped="no"/>
+                        <signal name="toggled" handler="random_interval_check_toggle" swapped="no" />
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -521,13 +533,15 @@
                         <property name="max-length">6</property>
                         <property name="width-chars">0</property>
                         <property name="placeholder-text" translatable="yes">+/-</property>
-                        <signal name="insert-text" handler="insert_handler" swapped="no"/>
+                        <signal name="insert-text" handler="insert_handler" swapped="no" />
+                        <signal name="changed" handler="input_changed_save_handler" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">2</property>
                       </packing>
                     </child>
+
                     <child>
                       <object class="GtkCheckButton" id="hold_time_check">
                         <property name="label" translatable="yes">Hold Time</property>
@@ -536,7 +550,7 @@
                         <property name="focus-on-click">False</property>
                         <property name="receives-default">False</property>
                         <property name="draw-indicator">True</property>
-                        <signal name="toggled" handler="hold_time_check_toggle" swapped="no"/>
+                        <signal name="toggled" handler="hold_time_check_toggle" swapped="no" />
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -553,13 +567,15 @@
                         <property name="max-length">6</property>
                         <property name="width-chars">0</property>
                         <property name="placeholder-text" translatable="yes">ms</property>
-                        <signal name="insert-text" handler="insert_handler" swapped="no"/>
+                        <signal name="insert-text" handler="insert_handler" swapped="no" />
+                        <signal name="changed" handler="input_changed_save_handler" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">3</property>
                       </packing>
                     </child>
+
                   </object>
                 </child>
                 <child type="label">
@@ -583,68 +599,6 @@
           </packing>
         </child>
         <child>
-          <object class="GtkFrame" id="preset_frame">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="margin-start">4</property>
-            <property name="margin-end">4</property>
-            <property name="label-xalign">0</property>
-            <property name="shadow-type">in</property>
-            <child>
-              <!-- n-columns=2 n-rows=1 -->
-              <object class="GtkGrid">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">6</property>
-                <property name="margin-end">5</property>
-                <property name="margin-top">5</property>
-                <property name="margin-bottom">5</property>
-                <property name="column-spacing">15</property>
-                <property name="row-homogeneous">True</property>
-                <property name="column-homogeneous">True</property>
-                <child>
-                  <object class="GtkButton" id="save_preset_button">
-                    <property name="label" translatable="yes">Save</property>
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">True</property>
-                    <signal name="pressed" handler="save_preset_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="load_preset_button">
-                    <property name="label" translatable="yes">Load</property>
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">True</property>
-                    <signal name="pressed" handler="load_preset_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-              </object>
-            </child>
-            <child type="label">
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Preset</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
           <!-- n-columns=3 n-rows=1 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
@@ -661,7 +615,7 @@
                 <property name="focus-on-click">False</property>
                 <property name="receives-default">True</property>
                 <property name="hexpand">True</property>
-                <signal name="pressed" handler="start_clicked" swapped="no"/>
+                <signal name="pressed" handler="start_clicked" swapped="no" />
               </object>
               <packing>
                 <property name="left-attach">0</property>
@@ -677,7 +631,7 @@
                 <property name="focus-on-click">False</property>
                 <property name="receives-default">True</property>
                 <property name="hexpand">True</property>
-                <signal name="pressed" handler="stop_clicked" swapped="no"/>
+                <signal name="pressed" handler="stop_clicked" swapped="no" />
               </object>
               <packing>
                 <property name="left-attach">1</property>
@@ -694,7 +648,7 @@
                 <property name="receives-default">True</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
-                <signal name="pressed" handler="settings_clicked" swapped="no"/>
+                <signal name="pressed" handler="settings_clicked" swapped="no" />
               </object>
               <packing>
                 <property name="left-attach">2</property>
@@ -705,7 +659,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/src/settings.c
+++ b/src/settings.c
@@ -306,7 +306,7 @@ void preset_write_to_config(struct Preset *preset)
 	g_key_file_set_string (config, PCK_CUSTOM_X, preset->custom_x);
 	g_key_file_set_string (config, PCK_CUSTOM_Y, preset->custom_y);
 	g_key_file_set_boolean(config, PCK_RANDOM_INTERVAL, preset->use_random_interval);
-	g_key_file_set_string (config, PCK_RANDOM_INTERVAL_MS, preset->custom_y);
+	g_key_file_set_string (config, PCK_RANDOM_INTERVAL_MS, preset->random_interval_ms);
 	g_key_file_set_boolean(config, PCK_HOLD_TIME, preset->use_hold_time);
 	g_key_file_set_string (config, PCK_HOLD_TIME_MS, preset->hold_time_ms);
 
@@ -333,7 +333,7 @@ struct Preset *preset_read_from_config()
 	preset->custom_x             = g_key_file_get_string (config, PCK_CUSTOM_X, NULL);
 	preset->custom_y             = g_key_file_get_string (config, PCK_CUSTOM_Y, NULL);
 	preset->use_random_interval  = g_key_file_get_boolean(config, PCK_RANDOM_INTERVAL, NULL);
-	preset->custom_y             = g_key_file_get_string (config, PCK_RANDOM_INTERVAL_MS, NULL);
+	preset->random_interval_ms   = g_key_file_get_string (config, PCK_RANDOM_INTERVAL_MS, NULL);
 	preset->use_hold_time        = g_key_file_get_boolean(config, PCK_HOLD_TIME, NULL);
 	preset->hold_time_ms         = g_key_file_get_string (config, PCK_HOLD_TIME_MS, NULL);
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -264,3 +264,78 @@ void settings_dialog_new()
     gtk_dialog_run(dialog);
     gtk_widget_destroy(GTK_WIDGET(dialog));
 }
+
+#define PRESET_CATEGORY_CLICK_INTERVAL "Preset.Click Interval"
+#define PRESET_CATEGORY_OPTIONS        "Preset.Options"
+#define PRESET_CATEGORY_MORE_OPTIONS   "Preset.More Options"
+
+/// PCK stand for preset-category-key. Below set of defines used to prevent typos
+#define PCK_HOURS              PRESET_CATEGORY_CLICK_INTERVAL, "Hours"
+#define PCK_MINUTES            PRESET_CATEGORY_CLICK_INTERVAL, "Minutes"
+#define PCK_SECONDS            PRESET_CATEGORY_CLICK_INTERVAL, "Seconds"
+#define PCK_MILLISECS          PRESET_CATEGORY_CLICK_INTERVAL, "Millisecs"
+
+#define PCK_MOUSE_BUTTON       PRESET_CATEGORY_OPTIONS, "Millisecs"
+#define PCK_CLICK_TYPE         PRESET_CATEGORY_OPTIONS, "Click Type"
+#define PCK_HOTKEY             PRESET_CATEGORY_OPTIONS, "Hotkey"
+#define PCK_REPEAT             PRESET_CATEGORY_OPTIONS, "Use Repeat"
+#define PCK_REPEAT_TIMES       PRESET_CATEGORY_OPTIONS, "Repeat Times"
+
+#define PCK_CUSTOM_LOCATION    PRESET_CATEGORY_MORE_OPTIONS, "Use Custom Location"
+#define PCK_CUSTOM_X           PRESET_CATEGORY_MORE_OPTIONS, "Custom X"
+#define PCK_CUSTOM_Y           PRESET_CATEGORY_MORE_OPTIONS, "Custom Y"
+#define PCK_RANDOM_INTERVAL    PRESET_CATEGORY_MORE_OPTIONS, "Use Random Interval"
+#define PCK_RANDOM_INTERVAL_MS PRESET_CATEGORY_MORE_OPTIONS, "Random Interval ms"
+#define PCK_HOLD_TIME          PRESET_CATEGORY_MORE_OPTIONS, "Use Hold Time"
+#define PCK_HOLD_TIME_MS       PRESET_CATEGORY_MORE_OPTIONS, "Hold Time ms"
+
+void preset_write_to_config(struct Preset *preset)
+{
+	g_key_file_set_string (config, PCK_HOURS, preset->hours);
+	g_key_file_set_string (config, PCK_MINUTES, preset->minutes);
+	g_key_file_set_string (config, PCK_SECONDS, preset->seconds);
+	g_key_file_set_string (config, PCK_MILLISECS, preset->millisecs);
+
+	g_key_file_set_string (config, PCK_MOUSE_BUTTON, preset->mouse_button);
+	g_key_file_set_string (config, PCK_CLICK_TYPE, preset->click_type);
+	g_key_file_set_string (config, PCK_HOTKEY, preset->hotkey);
+	g_key_file_set_boolean(config, PCK_REPEAT, preset->use_repeat);
+	g_key_file_set_string (config, PCK_REPEAT_TIMES, preset->repeat_times);
+
+	g_key_file_set_boolean(config, PCK_CUSTOM_LOCATION, preset->use_custom_location);
+	g_key_file_set_string (config, PCK_CUSTOM_X, preset->custom_x);
+	g_key_file_set_string (config, PCK_CUSTOM_Y, preset->custom_y);
+	g_key_file_set_boolean(config, PCK_RANDOM_INTERVAL, preset->use_random_interval);
+	g_key_file_set_string (config, PCK_RANDOM_INTERVAL_MS, preset->custom_y);
+	g_key_file_set_boolean(config, PCK_HOLD_TIME, preset->use_hold_time);
+	g_key_file_set_string (config, PCK_HOLD_TIME_MS, preset->hold_time_ms);
+
+	g_key_file_save_to_file(config, configpath, NULL);
+	g_free(preset);
+}
+
+struct Preset *preset_read_from_config()
+{
+	struct Preset *preset = g_malloc0(sizeof(*preset));
+
+	preset->hours                = g_key_file_get_string (config, PCK_HOURS, NULL);
+	preset->minutes              = g_key_file_get_string (config, PCK_MINUTES, NULL);
+	preset->seconds              = g_key_file_get_string (config, PCK_SECONDS, NULL);
+	preset->millisecs            = g_key_file_get_string (config, PCK_MILLISECS, NULL);
+
+	preset->mouse_button         = g_key_file_get_string (config, PCK_MOUSE_BUTTON, NULL);
+	preset->click_type           = g_key_file_get_string (config, PCK_CLICK_TYPE, NULL);
+	preset->hotkey               = g_key_file_get_string (config, PCK_HOTKEY, NULL);
+	preset->use_repeat           = g_key_file_get_boolean(config, PCK_REPEAT, NULL);
+	preset->repeat_times         = g_key_file_get_string (config, PCK_REPEAT_TIMES, NULL);
+
+	preset->use_custom_location  = g_key_file_get_boolean(config, PCK_CUSTOM_LOCATION, NULL);
+	preset->custom_x             = g_key_file_get_string (config, PCK_CUSTOM_X, NULL);
+	preset->custom_y             = g_key_file_get_string (config, PCK_CUSTOM_Y, NULL);
+	preset->use_random_interval  = g_key_file_get_boolean(config, PCK_RANDOM_INTERVAL, NULL);
+	preset->custom_y             = g_key_file_get_string (config, PCK_RANDOM_INTERVAL_MS, NULL);
+	preset->use_hold_time        = g_key_file_get_boolean(config, PCK_HOLD_TIME, NULL);
+	preset->hold_time_ms         = g_key_file_get_string (config, PCK_HOLD_TIME_MS, NULL);
+
+	return preset;
+}

--- a/src/settings.h
+++ b/src/settings.h
@@ -27,4 +27,40 @@ void load_start_stop_keybinds();
  */
 void settings_dialog_new();
 
+/**
+ * Represents all options you can see when starting xclicker.
+ */
+struct Preset
+{
+	/// click interval
+	const char * hours;
+	const char * minutes;
+	const char * seconds;
+	const char * millisecs;
+	/// opitons
+	const char * mouse_button;
+	const char * click_type;
+	const char * hotkey;
+	gboolean use_repeat;
+	const char * repeat_times;
+	/// more options
+	gboolean use_custom_location;
+	const char * custom_x;
+	const char * custom_y;
+	gboolean use_random_interval;
+	const char * random_interval_ms;
+	gboolean use_hold_time;
+	const char * hold_time_ms;
+};
+
+/**
+ * Write preset values to config file and save it.
+ */
+void preset_write_to_config(struct Preset *preset);
+
+/**
+ * Read preset values from the config.
+ */
+struct Preset *preset_read_from_config();
+
 #endif

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,66 +1,11 @@
 #ifndef __SETTINGSDIALOG_H
 #define __SETTINGSDIALOG_H
 
-extern int button1;
-extern int button2;
 extern gboolean isChoosingHotkey;
-
-/**
- * Checks if configured to use safe-mode.
- */
-gboolean is_safemode();
-
-/**
- * Checks if configured to use xevent.
- */
-gboolean is_using_xevent();
-
-/**
- * Loads config file if exists, else create it.
- */
-void config_init();
-
-void load_start_stop_keybinds();
 
 /**
  * Opens up a new settings dialog.
  */
 void settings_dialog_new();
-
-/**
- * Represents all options you can see when starting xclicker.
- */
-struct Preset
-{
-	/// click interval
-	const char * hours;
-	const char * minutes;
-	const char * seconds;
-	const char * millisecs;
-	/// opitons
-	const char * mouse_button;
-	const char * click_type;
-	const char * hotkey;
-	gboolean use_repeat;
-	const char * repeat_times;
-	/// more options
-	gboolean use_custom_location;
-	const char * custom_x;
-	const char * custom_y;
-	gboolean use_random_interval;
-	const char * random_interval_ms;
-	gboolean use_hold_time;
-	const char * hold_time_ms;
-};
-
-/**
- * Write preset values to config file and save it.
- */
-void preset_write_to_config(struct Preset *preset);
-
-/**
- * Read preset values from the config.
- */
-struct Preset *preset_read_from_config();
 
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -15,7 +15,17 @@ void xapp_error(const char *when, int code)
 
 void set_window_icon(GtkWindow *window)
 {
-    GdkPixbuf* pixbuf = gdk_pixbuf_new_from_resource("/res/icon.png", NULL);
+    GdkPixbuf *pixbuf = gdk_pixbuf_new_from_resource("/res/icon.png", NULL);
 
-	gtk_window_set_icon(window, pixbuf);
+    gtk_window_set_icon(window, pixbuf);
+}
+
+void gtk_entry_set_text_if_not_null(GtkEntry *entry, const gchar *text)
+{
+    if (text)
+    {
+        gtk_entry_set_text(entry, text);
+    } else {
+        gtk_entry_set_text(entry, ""); // for reseting field
+    }
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,4 +18,15 @@ void xapp_error(const char *when, int code);
  */
 void set_window_icon(GtkWindow *window);
 
+/**
+ * @brief Set the text of a GtkEntry widget if the provided text is not NULL.
+ *
+ * This function sets the text of the given GtkEntry widget if the provided
+ * text is not NULL. If the text is NULL, no action is taken.
+ *
+ * @param entry A pointer to the GtkEntry widget.
+ * @param text The text to set in the GtkEntry widget (can be NULL).
+ */
+void gtk_entry_set_text_if_not_null(GtkEntry *entry, const gchar *text);
+
 #endif


### PR DESCRIPTION
Closes #57 
I have added 2 buttons to save and load options to `~/.config/xclicker.conf`. It can be extended with file dialog to choose file location.

It is nowhere near perfect solution but it works for me.

Related to #57 