### PR TITLE
feat: random hold time support

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -122,6 +122,12 @@ struct Config *config_read_from_file()
         config->hotkey = "Normal";
     }
 
+    config->holdtime_type = g_key_file_get_string(config_gfile, PCK_HOLD_TIME_TYPE, NULL);
+    if (!config->holdtime_type)
+    {
+        config->holdtime_type = "Constant";
+    }
+
     config->use_repeat = g_key_file_get_boolean(config_gfile, PCK_REPEAT, NULL);
     config->repeat_times = g_key_file_get_string(config_gfile, PCK_REPEAT_TIMES, NULL);
 

--- a/src/config.h
+++ b/src/config.h
@@ -37,6 +37,7 @@ struct Config
 	const char *random_interval_ms;
 	gboolean use_hold_time;
 	const char *hold_time_ms;
+	const char *holdtime_type;
 };
 
 extern const char *configpath;
@@ -73,6 +74,7 @@ extern struct Config *config;
 #define PCK_RANDOM_INTERVAL_MS PRESET_CATEGORY_MORE_OPTIONS, "Random Interval ms"
 #define PCK_HOLD_TIME PRESET_CATEGORY_MORE_OPTIONS, "Use Hold Time"
 #define PCK_HOLD_TIME_MS PRESET_CATEGORY_MORE_OPTIONS, "Hold Time ms"
+#define PCK_HOLD_TIME_TYPE PRESET_CATEGORY_MORE_OPTIONS, "Hold Time Type"
 
 void config_init();
 

--- a/src/resources/ui/xclicker-window.ui
+++ b/src/resources/ui/xclicker-window.ui
@@ -19,6 +19,19 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="holdtimetype_lstore">
+    <columns>
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Constant</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Random</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkListStore" id="mouse_button_lstore">
     <columns>
       <!-- column-name gchararray1 -->
@@ -543,14 +556,54 @@
                     </child>
 
                     <child>
-                      <object class="GtkCheckButton" id="hold_time_check">
-                        <property name="label" translatable="yes">Hold Time</property>
+                      <!-- n-columns=2 n-rows=1 -->
+                      <object class="GtkGrid">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="focus-on-click">False</property>
-                        <property name="receives-default">False</property>
-                        <property name="draw-indicator">True</property>
-                        <signal name="toggled" handler="hold_time_check_toggle" swapped="no" />
+                        <property name="can-focus">False</property>
+                        <property name="column-spacing">10</property>
+                        <child>
+                          <object class="GtkCheckButton" id="hold_time_check">
+                            <property name="label" translatable="yes">Hold</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="focus-on-click">False</property>
+                            <property name="receives-default">False</property>
+                            <property name="draw-indicator">True</property>
+                            <signal name="toggled" handler="hold_time_check_toggle" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                        <object class="GtkComboBox">
+                         <property name="visible">True</property> 
+                         <property name="width-request">130</property> 
+                            <property name="model">holdtimetype_lstore</property>
+                            <property name="has-entry">True</property>
+                            <property name="entry-text-column">0</property>
+                            <property name="id-column">0</property>
+                            <property name="active-id">-1</property>
+                            <signal name="changed" handler="holdtime_type_entry_changed" swapped="no"/>
+                            <child>
+                              <object class="GtkCellRendererText"/>
+                            </child>
+                            <child internal-child="entry">
+                              <object class="GtkEntry" id="holdtime_type_entry">
+                                <property name="can-focus">True</property>
+                                <property name="editable">False</property>
+                                <property name="width-chars">0</property>
+                                <property name="text" translatable="yes">Constant</property>
+                                <property name="caps-lock-warning">False</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>


### PR DESCRIPTION
This commit introduces a hold time combo to simulate random hold time adding variability to hold duration, reducing the likelihood of bot detection.
![image](https://github.com/user-attachments/assets/4b2591e1-4867-4b58-8c2f-a220688078c9)