### PR TITLE
Add a setting to keep app above all windows

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -94,7 +94,7 @@ struct Config *config_read_from_file()
 
     config->safe_mode_enabled = g_key_file_get_boolean(config_gfile, CFGK_SAFEMODE, NULL);
     config->use_xevent = g_key_file_get_boolean(config_gfile, CFGK_USE_XEVENT, NULL);
-
+    config->keep_above_all = g_key_file_get_boolean(config_gfile, CFGK_KEEP_ABOVE_ALL, NULL);
     config->hours = g_key_file_get_string(config_gfile, PCK_HOURS, NULL);
     config->minutes = g_key_file_get_string(config_gfile, PCK_MINUTES, NULL);
     config->seconds = g_key_file_get_string(config_gfile, PCK_SECONDS, NULL);

--- a/src/config.h
+++ b/src/config.h
@@ -15,6 +15,7 @@ struct Config
 	int button2;
 	gboolean safe_mode_enabled;
 	gboolean use_xevent;
+	gboolean keep_above_all;
 
 	/// click interval
 	const char *hours;
@@ -54,6 +55,7 @@ extern struct Config *config;
 #define CFGK_BUTTON_2 CONFIG_CATEGORY_OPTIONS, "BUTTON2"
 #define CFGK_USE_XEVENT CONFIG_CATEGORY_OPTIONS, "USE_XEVENT"
 #define CFGK_SAFEMODE CONFIG_CATEGORY_OPTIONS, "SAFEMODE"
+#define CFGK_KEEP_ABOVE_ALL CONFIG_CATEGORY_OPTIONS, "KEEP_ABOVE_ALL"
 
 /// PCK stand for preset-category-key. Below set of defines used to prevent typos
 #define PCK_HOURS PRESET_CATEGORY_CLICK_INTERVAL, "Hours"

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -495,9 +495,9 @@ void mainappwindow_import_config()
 	gtk_entry_set_text_if_not_null(mainappwindow.holdtime_type_entry, config->holdtime_type);
 }
 
-void settings_clicked()
+void settings_clicked(GtkButton *button)
 {
-	settings_dialog_new();
+	settings_dialog_new(gtk_widget_get_toplevel(button));
 }
 
 void get_button_clicked()
@@ -725,6 +725,8 @@ static void main_app_window_init(MainAppWindow *win)
 	mainappwindow.stop_button = win->stop_button;
 	mainappwindow.settings_button = win->settings_button;
 	mainappwindow.get_button = win->get_button;
+
+	gtk_window_set_keep_above(win, config->keep_above_all);
 
 	set_start_stop_button_hotkey_text();
 	mainappwindow_import_config();

--- a/src/resources/ui/settings-dialog.ui
+++ b/src/resources/ui/settings-dialog.ui
@@ -169,6 +169,66 @@ gtk applications.</property>
                 <property name="margin-top">5</property>
                 <property name="margin-bottom">5</property>
                 <property name="spacing">10</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">This allows XClicker to be above all windows.</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="keep_above_switch">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="margin-top">10</property>
+                    <property name="margin-bottom">10</property>
+                    <property name="hexpand">True</property>
+                    <property name="active">True</property>
+                    <signal name="state-set" handler="keep_above_switch_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="padding">5</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Keep above all</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="spacing">10</property>
                 <property name="homogeneous">True</property>
                 <child>
                   <object class="GtkButton" id="start_button">
@@ -210,7 +270,7 @@ gtk applications.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
         <child>
@@ -256,7 +316,7 @@ gtk applications.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
         <child>
@@ -294,7 +354,7 @@ gtk applications.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">5</property>
           </packing>
         </child>
       </object>

--- a/src/settings.h
+++ b/src/settings.h
@@ -6,6 +6,6 @@ extern gboolean isChoosingHotkey;
 /**
  * Opens up a new settings dialog.
  */
-void settings_dialog_new();
+void settings_dialog_new(GtkWindow *parent);
 
 #endif


### PR DESCRIPTION
This PR introduces a new setting that allows the application to be above all windows at all times.
![keep_above_all](https://github.com/user-attachments/assets/f9049d83-fdb8-462a-8bbb-223b7e3d18c8)

Example:
![image](https://github.com/user-attachments/assets/34d0d08e-0efb-40cd-a6b5-c5537e70ac0c)
