### PR TITLE
Feat: Add System Tray Support for Background Running with Configurable Close Behavior

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,6 @@ add_project_arguments(
 
 
 gnome = import('gnome')
-deps = [dependency('gtk+-3.0'), dependency('x11'), dependency('xi'), dependency('xtst')]
+deps = [dependency('gtk+-3.0'), dependency('x11'), dependency('xi'), dependency('xtst'), dependency('appindicator3-0.1')]
 
 subdir('src')

--- a/src/config.c
+++ b/src/config.c
@@ -138,6 +138,13 @@ struct Config *config_read_from_file()
     config->random_interval_ms = g_key_file_get_string(config_gfile, PCK_RANDOM_INTERVAL_MS, NULL);
     config->use_hold_time = g_key_file_get_boolean(config_gfile, PCK_HOLD_TIME, NULL);
     config->hold_time_ms = g_key_file_get_string(config_gfile, PCK_HOLD_TIME_MS, NULL);
+    config->holdtime_type = g_key_file_get_string(config_gfile, PCK_HOLD_TIME_TYPE, NULL);
+
+    config->close_behavior = g_key_file_get_string(config_gfile, PCK_CLOSE_BEHAVIOR, NULL);
+    if (!config->close_behavior)
+    {
+        config->close_behavior = "Minimize to tray";
+    }
 
     return config;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -138,7 +138,6 @@ struct Config *config_read_from_file()
     config->random_interval_ms = g_key_file_get_string(config_gfile, PCK_RANDOM_INTERVAL_MS, NULL);
     config->use_hold_time = g_key_file_get_boolean(config_gfile, PCK_HOLD_TIME, NULL);
     config->hold_time_ms = g_key_file_get_string(config_gfile, PCK_HOLD_TIME_MS, NULL);
-    config->holdtime_type = g_key_file_get_string(config_gfile, PCK_HOLD_TIME_TYPE, NULL);
 
     config->close_behavior = g_key_file_get_string(config_gfile, PCK_CLOSE_BEHAVIOR, NULL);
     if (!config->close_behavior)

--- a/src/config.h
+++ b/src/config.h
@@ -38,6 +38,7 @@ struct Config
 	gboolean use_hold_time;
 	const char *hold_time_ms;
 	const char *holdtime_type;
+	const char *close_behavior;
 };
 
 extern const char *configpath;
@@ -75,6 +76,7 @@ extern struct Config *config;
 #define PCK_HOLD_TIME PRESET_CATEGORY_MORE_OPTIONS, "Use Hold Time"
 #define PCK_HOLD_TIME_MS PRESET_CATEGORY_MORE_OPTIONS, "Hold Time ms"
 #define PCK_HOLD_TIME_TYPE PRESET_CATEGORY_MORE_OPTIONS, "Hold Time Type"
+#define PCK_CLOSE_BEHAVIOR CONFIG_CATEGORY_OPTIONS, "Close Behavior"
 
 void config_init();
 

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -8,7 +8,7 @@
 #include "config.h"
 
 // Forward declaration
-static gboolean on_window_delete_event(GtkWidget *widget, GdkEvent *event, gpointer user_data);
+static gboolean on_window_delete_event(GtkWidget *widget);
 
 enum ClickTypes
 {
@@ -799,7 +799,7 @@ MainAppWindow *main_app_window_new(XClickerApp *app)
 /**
  * Handle window close event(hide window)
  */
-static gboolean on_window_delete_event(GtkWidget *widget, GdkEvent *event, gpointer user_data)
+static gboolean on_window_delete_event(GtkWidget *widget)
 {
 	if (config && config->close_behavior && strcmp(config->close_behavior, "Close application") == 0)
 	{

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -80,7 +80,7 @@ struct click_opts
 
 	gboolean hold_time;
 	int hold_time_ms;
-	int	holdtime_type;
+	int holdtime_type;
 };
 
 /**
@@ -129,7 +129,7 @@ void click_handler(gpointer *data)
 	int hold_type_ms = 0;
 	if (args->hold_time == TRUE)
 	{
-		hold_type_ms=args->hold_time_ms* 1000 ;
+		hold_type_ms = args->hold_time_ms * 1000;
 	}
 
 	while (isClicking)
@@ -138,9 +138,9 @@ void click_handler(gpointer *data)
 			move_to(display, args->custom_x, args->custom_y);
 
 		// reassigning a new hold time
-		if (args->hold_time == TRUE && args->holdtime_type==HOLDTIME_TYPE_RANDOM)
+		if (args->hold_time == TRUE && args->holdtime_type == HOLDTIME_TYPE_RANDOM)
 		{
-			hold_type_ms=random_between(0, args->hold_time_ms)* 1000 ;
+			hold_type_ms = random_between(0, args->hold_time_ms) * 1000;
 		}
 
 		switch (args->click_type)
@@ -701,7 +701,7 @@ static void main_app_window_init(MainAppWindow *win)
 	config_init();
 
 	mainappwindow.pwin = gtk_widget_get_toplevel(win);
-	
+
 	// Connect delete event to hide window
 	g_signal_connect(win, "delete-event", G_CALLBACK(on_window_delete_event), NULL);
 
@@ -801,6 +801,18 @@ MainAppWindow *main_app_window_new(XClickerApp *app)
  */
 static gboolean on_window_delete_event(GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
-	gtk_widget_hide(widget);
-	return TRUE;
+	if (config && config->close_behavior && strcmp(config->close_behavior, "Close application") == 0)
+	{
+		// Close the whole application
+		XClickerApp *app = XCLICKER_APP(gtk_window_get_application(GTK_WINDOW(widget)));
+		if (app)
+			xclicker_app_quit(app);
+		return TRUE;
+	}
+	else
+	{
+		// Hide to system tray
+		gtk_widget_hide(widget);
+		return TRUE;
+	}
 }

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -7,6 +7,9 @@
 #include "utils.h"
 #include "config.h"
 
+// Forward declaration
+static gboolean on_window_delete_event(GtkWidget *widget, GdkEvent *event, gpointer user_data);
+
 enum ClickTypes
 {
 	CLICK_TYPE_SINGLE,
@@ -698,6 +701,9 @@ static void main_app_window_init(MainAppWindow *win)
 	config_init();
 
 	mainappwindow.pwin = gtk_widget_get_toplevel(win);
+	
+	// Connect delete event to hide window
+	g_signal_connect(win, "delete-event", G_CALLBACK(on_window_delete_event), NULL);
 
 	// Entries
 	mainappwindow.hours_entry = win->hours_entry;
@@ -788,4 +794,13 @@ static void main_app_window_class_init(MainAppWindowClass *class)
 MainAppWindow *main_app_window_new(XClickerApp *app)
 {
 	return g_object_new(MAIN_APP_WINDOW_TYPE, "application", app, NULL);
+}
+
+/**
+ * Handle window close event(hide window)
+ */
+static gboolean on_window_delete_event(GtkWidget *widget, GdkEvent *event, gpointer user_data)
+{
+	gtk_widget_hide(widget);
+	return TRUE;
 }

--- a/src/resources/ui/settings-dialog.ui
+++ b/src/resources/ui/settings-dialog.ui
@@ -31,6 +31,7 @@
             <property name="position">0</property>
           </packing>
         </child>
+        <!-- Safe mode -->
         <child>
           <object class="GtkFrame">
             <property name="visible">True</property>
@@ -92,6 +93,7 @@ milliseconds interval.</property>
             <property name="position">0</property>
           </packing>
         </child>
+        <!-- Use XEvent -->
         <child>
           <object class="GtkFrame">
             <property name="visible">True</property>
@@ -154,6 +156,7 @@ gtk applications.</property>
             <property name="position">1</property>
           </packing>
         </child>
+        <!-- Start/Stop Hotkey -->
         <child>
           <object class="GtkFrame">
             <property name="visible">True</property>
@@ -213,6 +216,69 @@ gtk applications.</property>
             <property name="position">2</property>
           </packing>
         </child>
+        <!-- Window Close Behavior (moved before Reset) -->
+        <child>
+          <object class="GtkFrame">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="spacing">10</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">When closing the window:</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBoxText" id="close_behavior_combo">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="active">0</property>
+                    <items>
+                      <item id="Minimize" translatable="yes">Minimize to tray</item>
+                      <item id="Close" translatable="yes">Close application</item>
+                    </items>
+                    <signal name="changed" handler="close_behavior_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="padding">5</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Window Close Behavior</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <!-- Reset -->
         <child>
           <object class="GtkFrame">
             <property name="visible">True</property>
@@ -256,9 +322,10 @@ gtk applications.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="position">3</property>
+            <property name="position">5</property>
           </packing>
         </child>
+        <!-- Version and Link -->
         <child>
           <!-- n-columns=1 n-rows=2 -->
           <object class="GtkGrid">
@@ -294,7 +361,7 @@ gtk applications.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">6</property>
           </packing>
         </child>
       </object>

--- a/src/settings.c
+++ b/src/settings.c
@@ -154,6 +154,17 @@ void reset_preset_button_pressed()
     mainappwindow_import_config();
 }
 
+void close_behavior_changed(GtkComboBoxText *combo_box)
+{
+    const gchar *selected_behavior = gtk_combo_box_text_get_active_text(combo_box);
+    if (selected_behavior)
+    {
+        g_key_file_set_string(config_gfile, PCK_CLOSE_BEHAVIOR, selected_behavior);
+        g_key_file_save_to_file(config_gfile, configpath, NULL);
+        config->close_behavior = selected_behavior;
+    }
+}
+
 void settings_dialog_new()
 {
     GtkBuilder *builder = gtk_builder_new_from_resource("/res/ui/settings-dialog.ui");
@@ -167,6 +178,7 @@ void settings_dialog_new()
     gtk_builder_add_callback_symbol(builder, "xevent_switch_changed", xevent_switch_changed);
     gtk_builder_add_callback_symbol(builder, "start_button_pressed", start_button_pressed);
     gtk_builder_add_callback_symbol(builder, "reset_preset_button_pressed", reset_preset_button_pressed);
+    gtk_builder_add_callback_symbol(builder, "close_behavior_changed", close_behavior_changed);
 
     gtk_builder_connect_signals(builder, NULL);
 
@@ -181,6 +193,16 @@ void settings_dialog_new()
     // Load
     gtk_switch_set_active(GTK_SWITCH(gtk_builder_get_object(builder, "safe_mode_switch")), is_safemode());
     gtk_switch_set_active(GTK_SWITCH(items.xevent_switch), config->use_xevent);
+
+    // Load close behavior
+    GtkWidget *close_behavior_combo = gtk_builder_get_object(builder, "close_behavior_combo");
+    if (config->close_behavior)
+    {
+        if (strcmp(config->close_behavior, "Close application") == 0)
+            gtk_combo_box_set_active(GTK_COMBO_BOX(close_behavior_combo), 1);
+        else
+            gtk_combo_box_set_active(GTK_COMBO_BOX(close_behavior_combo), 0); // Minimize to tray default
+    }
 
     // Load hotkeys
     Display *display = get_display();

--- a/src/xclicker-app.c
+++ b/src/xclicker-app.c
@@ -2,27 +2,86 @@
 
 #include "xclicker-app.h"
 #include "mainwin.h"
+#include "utils.h"
 
 struct _XClickerApp
 {
 	GtkApplication parent;
+	GtkStatusIcon *status_icon;
+	MainAppWindow *main_window;
+	gboolean window_visible;
 };
 
 G_DEFINE_TYPE(XClickerApp, xclicker_app, GTK_TYPE_APPLICATION);
 
-static void xclicker_app_init(XClickerApp* /*app*/)
+static void status_icon_activate(GtkStatusIcon *status_icon, XClickerApp *app);
+static void status_icon_popup_menu(GtkStatusIcon *status_icon, guint button, guint activate_time, XClickerApp *app);
+
+static void xclicker_app_init(XClickerApp *app)
 {
+	app->status_icon = NULL;
+	app->main_window = NULL;
+	app->window_visible = FALSE;
+}
+
+/**
+ * Creates and shows the system tray icon
+ */
+static void create_status_icon(XClickerApp *app)
+{
+	if (app->status_icon)
+	{
+		return;
+	}
+
+	// Try to load custom icon first, fallback to system icon
+	GError *error = NULL;
+	GdkPixbuf *pixbuf = gdk_pixbuf_new_from_resource("/res/icon.png", &error);
+
+	if (pixbuf)
+	{
+		app->status_icon = gtk_status_icon_new_from_pixbuf(pixbuf);
+		g_object_unref(pixbuf);
+	}
+
+	gtk_status_icon_set_visible(app->status_icon, TRUE);
+	gtk_status_icon_set_tooltip_text(app->status_icon, "XClicker");
+	gtk_status_icon_set_has_tooltip(app->status_icon, TRUE);
+
+	g_signal_connect(app->status_icon, "activate", G_CALLBACK(status_icon_activate), app);
+	g_signal_connect(app->status_icon, "popup-menu", G_CALLBACK(status_icon_popup_menu), app);
 }
 
 /**
  * Opens up main window.
  */
-static void xclicker_app_activate(GApplication *app)
+static void xclicker_app_activate(GApplication *gapp)
 {
-	MainAppWindow *win = main_app_window_new(XCLICKER_APP(app));
-	gtk_window_present(GTK_WINDOW(win));
-}
+	XClickerApp *app = XCLICKER_APP(gapp);
 
+	if (!app->main_window)
+	{
+		app->main_window = main_app_window_new(app);
+		app->window_visible = TRUE;
+
+		// Connect to window hide event
+		g_signal_connect(app->main_window, "hide", G_CALLBACK(gtk_widget_hide_on_delete), NULL);
+		g_signal_connect(app->main_window, "delete-event", G_CALLBACK(gtk_widget_hide_on_delete), NULL);
+	}
+
+	if (!app->window_visible)
+	{
+		gtk_window_present(GTK_WINDOW(app->main_window));
+		app->window_visible = TRUE;
+	}
+
+	// Create status icon after window is created
+	create_status_icon(app);
+
+	// Show window immediately on startup
+	gtk_window_present(GTK_WINDOW(app->main_window));
+	app->window_visible = TRUE;
+}
 
 static void xclicker_app_class_init(XClickerAppClass *class)
 {
@@ -32,4 +91,58 @@ static void xclicker_app_class_init(XClickerAppClass *class)
 XClickerApp *xclicker_app_new()
 {
 	return g_object_new(XCLICKER_APP_TYPE, NULL);
+}
+
+/**
+ * Show window when status icon is left-clicked.
+ */
+static void status_icon_activate(GtkStatusIcon *status_icon, XClickerApp *app)
+{
+	show_window(app);
+}
+
+/**
+ * Show popup menu when status icon is right-clicked.
+ */
+static void status_icon_popup_menu(GtkStatusIcon *status_icon, guint button, guint activate_time, XClickerApp *app)
+{
+	GtkWidget *menu = gtk_menu_new();
+
+	// Show menu item
+	GtkWidget *toggle_item = gtk_menu_item_new_with_label("Show Window");
+	g_signal_connect_swapped(toggle_item, "activate",
+							 G_CALLBACK(show_window), app);
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), toggle_item);
+
+	// Separator
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+
+	// Quit menu item
+	GtkWidget *quit_item = gtk_menu_item_new_with_label("Quit");
+	g_signal_connect_swapped(quit_item, "activate",
+							 G_CALLBACK(xclicker_app_quit), app);
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), quit_item);
+
+	gtk_widget_show_all(menu);
+	gtk_menu_popup_at_pointer(GTK_MENU(menu), NULL);
+}
+
+/**
+ * Shows the main window.
+ */
+void show_window(XClickerApp *app)
+{
+	if (!app->main_window)
+		return;
+
+	gtk_window_present(GTK_WINDOW(app->main_window));
+	app->window_visible = TRUE;
+}
+
+/**
+ * Quits the application completely.
+ */
+void xclicker_app_quit(XClickerApp *app)
+{
+	g_application_quit(G_APPLICATION(app));
 }

--- a/src/xclicker-app.c
+++ b/src/xclicker-app.c
@@ -1,4 +1,5 @@
 #include <gtk/gtk.h>
+#include <libappindicator/app-indicator.h>
 
 #include "xclicker-app.h"
 #include "mainwin.h"
@@ -7,19 +8,16 @@
 struct _XClickerApp
 {
 	GtkApplication parent;
-	GtkStatusIcon *status_icon;
+	AppIndicator *app_indicator;
 	MainAppWindow *main_window;
 	gboolean window_visible;
 };
 
 G_DEFINE_TYPE(XClickerApp, xclicker_app, GTK_TYPE_APPLICATION);
 
-static void status_icon_activate(GtkStatusIcon *status_icon, XClickerApp *app);
-static void status_icon_popup_menu(GtkStatusIcon *status_icon, guint button, guint activate_time, XClickerApp *app);
-
 static void xclicker_app_init(XClickerApp *app)
 {
-	app->status_icon = NULL;
+	app->app_indicator = NULL;
 	app->main_window = NULL;
 	app->window_visible = FALSE;
 }
@@ -27,29 +25,40 @@ static void xclicker_app_init(XClickerApp *app)
 /**
  * Creates and shows the system tray icon
  */
-static void create_status_icon(XClickerApp *app)
+static void create_app_indicator(XClickerApp *app)
 {
-	if (app->status_icon)
+	if (app->app_indicator)
 	{
 		return;
 	}
 
-	// Load icon
-	GError *error = NULL;
-	GdkPixbuf *pixbuf = gdk_pixbuf_new_from_resource("/res/icon.png", &error);
+	// Create the app indicator
+	app->app_indicator = app_indicator_new("xclicker", "xclicker", APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+	app_indicator_set_icon_full(app->app_indicator, "xclicker", "XClicker");
+	GtkWidget *menu = gtk_menu_new();
 
-	if (pixbuf)
-	{
-		app->status_icon = gtk_status_icon_new_from_pixbuf(pixbuf);
-		g_object_unref(pixbuf);
-	}
+	// Show menu item
+	GtkWidget *toggle_item = gtk_menu_item_new_with_label("Show Window");
+	g_signal_connect_swapped(toggle_item, "activate",
+							 G_CALLBACK(show_window), app);
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), toggle_item);
 
-	gtk_status_icon_set_visible(app->status_icon, TRUE);
-	gtk_status_icon_set_tooltip_text(app->status_icon, "XClicker");
-	gtk_status_icon_set_has_tooltip(app->status_icon, TRUE);
+	// Separator
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
-	g_signal_connect(app->status_icon, "activate", G_CALLBACK(status_icon_activate), app);
-	g_signal_connect(app->status_icon, "popup-menu", G_CALLBACK(status_icon_popup_menu), app);
+	// Quit menu item
+	GtkWidget *quit_item = gtk_menu_item_new_with_label("Quit");
+	g_signal_connect_swapped(quit_item, "activate",
+							 G_CALLBACK(xclicker_app_quit), app);
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), quit_item);
+
+	gtk_widget_show_all(menu);
+
+	// Set the menu for the indicator
+	app_indicator_set_menu(app->app_indicator, GTK_MENU(menu));
+
+	// Set the indicator active
+	app_indicator_set_status(app->app_indicator, APP_INDICATOR_STATUS_ACTIVE);
 }
 
 /**
@@ -75,8 +84,8 @@ static void xclicker_app_activate(GApplication *gapp)
 		app->window_visible = TRUE;
 	}
 
-	// Create status icon after window is created
-	create_status_icon(app);
+	// Create app indicator after window is created
+	create_app_indicator(app);
 
 	// Show window immediately on startup
 	gtk_window_present(GTK_WINDOW(app->main_window));
@@ -91,40 +100,6 @@ static void xclicker_app_class_init(XClickerAppClass *class)
 XClickerApp *xclicker_app_new()
 {
 	return g_object_new(XCLICKER_APP_TYPE, NULL);
-}
-
-/**
- * Show window when status icon is left-clicked.
- */
-static void status_icon_activate(GtkStatusIcon *status_icon, XClickerApp *app)
-{
-	show_window(app);
-}
-
-/**
- * Show popup menu when status icon is right-clicked.
- */
-static void status_icon_popup_menu(GtkStatusIcon *status_icon, guint button, guint activate_time, XClickerApp *app)
-{
-	GtkWidget *menu = gtk_menu_new();
-
-	// Show menu item
-	GtkWidget *toggle_item = gtk_menu_item_new_with_label("Show Window");
-	g_signal_connect_swapped(toggle_item, "activate",
-							 G_CALLBACK(show_window), app);
-	gtk_menu_shell_append(GTK_MENU_SHELL(menu), toggle_item);
-
-	// Separator
-	gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
-
-	// Quit menu item
-	GtkWidget *quit_item = gtk_menu_item_new_with_label("Quit");
-	g_signal_connect_swapped(quit_item, "activate",
-							 G_CALLBACK(xclicker_app_quit), app);
-	gtk_menu_shell_append(GTK_MENU_SHELL(menu), quit_item);
-
-	gtk_widget_show_all(menu);
-	gtk_menu_popup_at_pointer(GTK_MENU(menu), NULL);
 }
 
 /**

--- a/src/xclicker-app.c
+++ b/src/xclicker-app.c
@@ -34,7 +34,7 @@ static void create_status_icon(XClickerApp *app)
 		return;
 	}
 
-	// Try to load custom icon first, fallback to system icon
+	// Load icon
 	GError *error = NULL;
 	GdkPixbuf *pixbuf = gdk_pixbuf_new_from_resource("/res/icon.png", &error);
 

--- a/src/xclicker-app.h
+++ b/src/xclicker-app.h
@@ -11,4 +11,14 @@ G_DECLARE_FINAL_TYPE(XClickerApp, xclicker_app, XCLICKER, APP, GtkApplication)
  */
 XClickerApp *xclicker_app_new();
 
+/**
+ * Shows the main window.
+ */
+void show_window(XClickerApp *app);
+
+/**
+ * Quits the application completely.
+ */
+void xclicker_app_quit(XClickerApp *app);
+
 #endif

--- a/src/xclicker-app.h
+++ b/src/xclicker-app.h
@@ -2,6 +2,7 @@
 #define __XCLICKERAPP_H
 
 #include <gtk/gtk.h>
+#include <libappindicator/app-indicator.h>
 
 #define XCLICKER_APP_TYPE (xclicker_app_get_type())
 G_DECLARE_FINAL_TYPE(XClickerApp, xclicker_app, XCLICKER, APP, GtkApplication)


### PR DESCRIPTION
This PR adds system tray (indicator) support, allowing the application to run in the background and be controlled through the indicator icon. A new configuration option is added to control **the window close behavior** (minimize to tray vs. close application). This is particularly useful for window managers like i3 *(and that was also my specific use case)* where users want to keep the autoclicker running without keeping the main window open.

*Notes: These changes have been tested specifically in i3 window manager environment. Testing in other desktop environments was not performed due to environment limitations.*